### PR TITLE
ci(workflows): standardize Go version and add just tasks

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,6 +1,25 @@
 version: 2
 updates:
-  - package-ecosystem: 'gomod'
-    directory: '/'
+  # CLI - Go modules
+  - package-ecosystem: "gomod"
+    directory: "/"
     schedule:
-      interval: 'monthly'
+      interval: "monthly"
+    labels:
+      - "cli"
+      - "deps"
+    commit-message:
+      prefix: "build"
+    open-pull-requests-limit: 5
+
+  # GitHub Actions
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "monthly"
+    labels:
+      - "ci"
+      - "deps"
+    commit-message:
+      prefix: "ci"
+    open-pull-requests-limit: 3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,9 @@ on:
     branches: "**"
   workflow_dispatch:
 
+env:
+  GO_VERSION: "1.25"
+
 jobs:
   lint:
     name: lint
@@ -18,7 +21,8 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
-          go-version: "1.25"
+          go-version: ${{ env.GO_VERSION }}
+          cache-dependency-path: go.sum
           check-latest: true
 
       - name: Install Go modules
@@ -27,10 +31,27 @@ jobs:
       - name: Verify dependencies
         run: go mod verify
 
-      - name: golangci-lint
+      - name: Install just
+        uses: taiki-e/install-action@v2
+        with:
+          tool: just
+
+      - name: Install golangci-lint
         uses: golangci/golangci-lint-action@v9
         with:
           version: latest
+          install-mode: binary
+          skip-cache: false
+
+      - name: Install Go tools
+        run: |
+          go install golang.org/x/tools/gopls/internal/analysis/modernize/cmd/modernize@latest
+
+      - name: Run go modernize
+        run: just modernize
+
+      - name: Run golangci-lint
+        run: just lint
 
   test:
     name: test
@@ -44,7 +65,8 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
-          go-version: "1.25"
+          go-version: ${{ env.GO_VERSION }}
+          cache-dependency-path: go.sum
           check-latest: true
 
       - name: Install Go modules
@@ -53,5 +75,10 @@ jobs:
       - name: Verify dependencies
         run: go mod verify
 
-      - name: Run tests
-        run: go test $(go list ./... | grep -Ev 'internal/testutils') -covermode=atomic
+      - name: Install just
+        uses: taiki-e/install-action@v2
+        with:
+          tool: just
+
+      - name: Run test
+        run: just test

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -5,6 +5,9 @@ on:
     branches: [main]
   workflow_dispatch:
 
+env:
+  GO_VERSION: "1.25"
+
 jobs:
   coverage:
     runs-on: ubuntu-latest
@@ -15,7 +18,8 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
-          go-version: "1.25"
+          go-version: ${{ env.GO_VERSION }}
+          cache-dependency-path: go.sum
           check-latest: true
 
       - name: Install Go modules
@@ -24,8 +28,13 @@ jobs:
       - name: Verify dependencies
         run: go mod verify
 
-      - name: Run go test
-        run: go test -count=1 -timeout 30s $(go list ./... | grep -Ev 'internal/testutils') -covermode=atomic -coverprofile=coverage.txt
+      - name: Install just
+        uses: taiki-e/install-action@v2
+        with:
+          tool: just
+
+      - name: Run test
+        run: just test-coverage
 
       - name: Upload coverage reports to Codecov
         uses: codecov/codecov-action@v5

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,6 +2,10 @@ name: Release
 on:
   release:
     types: [created]
+
+env:
+  GO_VERSION: "1.25"
+
 jobs:
   create-release-notes:
     name: release-notes
@@ -39,7 +43,8 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
-          go-version: "1.25"
+          go-version: ${{ env.GO_VERSION }}
+          cache-dependency-path: go.sum
           check-latest: true
 
       - name: Run GoReleaser
@@ -49,4 +54,4 @@ jobs:
           version: latest
           args: release --clean
         env:
-          GITHUB_TOKEN: ${{ secrets.SLEY_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.HOMEBREW_TOKEN }}

--- a/justfile
+++ b/justfile
@@ -55,9 +55,9 @@ reportcard:
     @echo "* Running goreportcard-cli..."
     goreportcard-cli -v
 
-# Run all tests and generate coverage report
+# Run all tests and print code coverage value
 test:
-    @echo "* Run all tests and generate coverage report."
+    @echo "* Run all tests and print code coverage value."
     {{ go }} test $({{ go }} list ./... | grep -Ev 'internal/testutils') -coverprofile=coverage.txt
     @echo "* Total Coverage"
     {{ go }} tool cover -func=coverage.txt | grep total | awk '{print $3}'
@@ -67,6 +67,11 @@ test-force:
     @echo "* Clean go tests cache and run all tests."
     {{ go }} clean -testcache
     just test
+
+# Run all tests and generate coverage report.
+test-coverage:
+    @echo "* Run all tests and generate coverage report."
+    go test -count=1 -timeout 30s $(go list ./... | grep -Ev 'internal/testutils') -covermode=atomic -coverprofile=coverage.txt
 
 # Run modernize, lint, and reportcard
 check: modernize lint reportcard


### PR DESCRIPTION
## Summary


- Standardize Go version across all workflows using env variable
- Improve caching with cache-dependency-path
- Add `go modernize` check to CI pipeline
- Use just recipes for consistent test/lint commands
- Enhance dependabot to monitor GitHub Actions