### PR TITLE
feat(init): add --template flag for pre-configured plugin sets

### DIFF
--- a/README.md
+++ b/README.md
@@ -215,6 +215,9 @@ sley init
 # Non-interactive with sensible defaults
 sley init --yes
 
+# Use a pre-configured template
+sley init --template automation
+
 # Enable specific plugins
 sley init --enable commit-parser,tag-manager,changelog-generator
 
@@ -227,9 +230,20 @@ sley init --path internal/version/.version
 | Flag           | Description                                               |
 | -------------- | --------------------------------------------------------- |
 | `--yes`, `-y`  | Use defaults without prompts (commit-parser, tag-manager) |
+| `--template`   | Use a pre-configured template (see below)                 |
 | `--enable`     | Comma-separated list of plugins to enable                 |
 | `--force`      | Overwrite existing .sley.yaml                             |
 | `--path`, `-p` | Custom path for .version file                             |
+
+**Available templates:**
+
+| Template     | Plugins Enabled                                             |
+| ------------ | ----------------------------------------------------------- |
+| `basic`      | commit-parser                                               |
+| `git`        | commit-parser, tag-manager                                  |
+| `automation` | commit-parser, tag-manager, changelog-generator             |
+| `strict`     | commit-parser, tag-manager, version-validator, release-gate |
+| `full`       | All plugins enabled                                         |
 
 **To disable auto-initialization**, use the `--strict` flag.
 This is useful in CI/CD environments or stricter workflows where you want the command to fail if the file is missing:

--- a/cmd/sley/initcmd/initcmd_test.go
+++ b/cmd/sley/initcmd/initcmd_test.go
@@ -280,22 +280,125 @@ func TestCLI_InitCommand_WithEnableFlag(t *testing.T) {
 	}
 }
 
+func TestCLI_InitCommand_WithTemplateFlag(t *testing.T) {
+	tests := []struct {
+		name             string
+		template         string
+		commitParser     bool
+		tagManager       bool
+		changelogGen     bool
+		versionValidator bool
+		releaseGate      bool
+	}{
+		{"basic template", "basic", true, false, false, false, false},
+		{"git template", "git", true, true, false, false, false},
+		{"automation template", "automation", true, true, true, false, false},
+		{"strict template", "strict", true, true, false, true, true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			loadedCfg := runInitWithTemplate(t, tt.template)
+			verifyTemplatePlugins(t, loadedCfg.Plugins, tt)
+		})
+	}
+}
+
+// runInitWithTemplate runs sley init with the given template and returns the loaded config.
+func runInitWithTemplate(t *testing.T, template string) config.Config {
+	t.Helper()
+
+	tmp := t.TempDir()
+	versionPath := filepath.Join(tmp, ".version")
+	configPath := filepath.Join(tmp, ".sley.yaml")
+
+	t.Chdir(tmp)
+
+	cfg := &config.Config{Path: versionPath}
+	appCli := testutils.BuildCLIForTests(cfg.Path, []*cli.Command{Run()})
+
+	if err := appCli.Run(context.Background(), []string{"sley", "init", "--template", template}); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	configData, err := os.ReadFile(configPath)
+	if err != nil {
+		t.Fatalf("failed to read config: %v", err)
+	}
+
+	var loadedCfg config.Config
+	if err := yaml.Unmarshal(configData, &loadedCfg); err != nil {
+		t.Fatalf("failed to parse config: %v", err)
+	}
+
+	if loadedCfg.Plugins == nil {
+		t.Fatal("expected plugins config")
+	}
+
+	return loadedCfg
+}
+
+// verifyTemplatePlugins checks that the loaded plugins match the expected configuration.
+func verifyTemplatePlugins(t *testing.T, plugins *config.PluginConfig, expected struct {
+	name             string
+	template         string
+	commitParser     bool
+	tagManager       bool
+	changelogGen     bool
+	versionValidator bool
+	releaseGate      bool
+}) {
+	t.Helper()
+
+	checks := []struct {
+		name     string
+		got      bool
+		expected bool
+	}{
+		{"commit-parser", plugins.CommitParser, expected.commitParser},
+		{"tag-manager", plugins.TagManager != nil && plugins.TagManager.Enabled, expected.tagManager},
+		{"changelog-generator", plugins.ChangelogGenerator != nil && plugins.ChangelogGenerator.Enabled, expected.changelogGen},
+		{"version-validator", plugins.VersionValidator != nil && plugins.VersionValidator.Enabled, expected.versionValidator},
+		{"release-gate", plugins.ReleaseGate != nil && plugins.ReleaseGate.Enabled, expected.releaseGate},
+	}
+
+	for _, c := range checks {
+		if c.got != c.expected {
+			t.Errorf("%s: expected %v, got %v", c.name, c.expected, c.got)
+		}
+	}
+}
+
+func TestCLI_InitCommand_WithInvalidTemplate(t *testing.T) {
+	tmp := t.TempDir()
+	versionPath := filepath.Join(tmp, ".version")
+
+	t.Chdir(tmp)
+
+	cfg := &config.Config{Path: versionPath}
+	appCli := testutils.BuildCLIForTests(
+		cfg.Path,
+		[]*cli.Command{Run()},
+	)
+
+	err := appCli.Run(context.Background(), []string{
+		"sley", "init", "--template", "invalid-template",
+	})
+	if err == nil {
+		t.Fatal("expected error for invalid template, got nil")
+	}
+
+	if !strings.Contains(err.Error(), "unknown template") {
+		t.Errorf("expected 'unknown template' error, got: %v", err)
+	}
+}
+
 func TestCLI_InitCommand_WithForceFlag(t *testing.T) {
 	tmp := t.TempDir()
 	versionPath := filepath.Join(tmp, ".version")
 	configPath := filepath.Join(tmp, ".sley.yaml")
 
-	originalDir, err := os.Getwd()
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer func() {
-		_ = os.Chdir(originalDir)
-	}()
-
-	if err := os.Chdir(tmp); err != nil {
-		t.Fatal(err)
-	}
+	t.Chdir(tmp)
 
 	// Create existing config with different content
 	existingConfig := []byte("path: .version\nplugins:\n  commit-parser: false\n")
@@ -309,7 +412,7 @@ func TestCLI_InitCommand_WithForceFlag(t *testing.T) {
 		[]*cli.Command{Run()},
 	)
 
-	err = appCli.Run(context.Background(), []string{
+	err := appCli.Run(context.Background(), []string{
 		"sley", "init", "--yes", "--force",
 	})
 	if err != nil {
@@ -409,44 +512,103 @@ func TestInitializeVersionFile(t *testing.T) {
 
 func TestDeterminePlugins(t *testing.T) {
 	tests := []struct {
-		name       string
-		ctx        *ProjectContext
-		yesFlag    bool
-		enableFlag string
-		expected   []string
+		name         string
+		ctx          *ProjectContext
+		yesFlag      bool
+		templateFlag string
+		enableFlag   string
+		expected     []string
+		expectError  bool
 	}{
 		{
-			name:       "enable flag takes priority",
-			ctx:        &ProjectContext{},
-			yesFlag:    true,
-			enableFlag: "audit-log",
-			expected:   []string{"audit-log"},
+			name:         "enable flag takes priority over all",
+			ctx:          &ProjectContext{},
+			yesFlag:      true,
+			templateFlag: "strict",
+			enableFlag:   "audit-log",
+			expected:     []string{"audit-log"},
 		},
 		{
-			name:       "yes flag uses defaults",
-			ctx:        &ProjectContext{},
-			yesFlag:    true,
-			enableFlag: "",
-			expected:   DefaultPluginNames(),
+			name:         "template flag takes priority over yes",
+			ctx:          &ProjectContext{},
+			yesFlag:      true,
+			templateFlag: "basic",
+			enableFlag:   "",
+			expected:     []string{"commit-parser"},
 		},
 		{
-			name:       "multiple plugins in enable flag",
-			ctx:        &ProjectContext{},
-			yesFlag:    false,
-			enableFlag: "commit-parser,tag-manager,audit-log",
-			expected:   []string{"commit-parser", "tag-manager", "audit-log"},
+			name:         "yes flag uses defaults",
+			ctx:          &ProjectContext{},
+			yesFlag:      true,
+			templateFlag: "",
+			enableFlag:   "",
+			expected:     DefaultPluginNames(),
+		},
+		{
+			name:         "multiple plugins in enable flag",
+			ctx:          &ProjectContext{},
+			yesFlag:      false,
+			templateFlag: "",
+			enableFlag:   "commit-parser,tag-manager,audit-log",
+			expected:     []string{"commit-parser", "tag-manager", "audit-log"},
+		},
+		{
+			name:         "template basic",
+			ctx:          &ProjectContext{},
+			yesFlag:      false,
+			templateFlag: "basic",
+			enableFlag:   "",
+			expected:     []string{"commit-parser"},
+		},
+		{
+			name:         "template git",
+			ctx:          &ProjectContext{},
+			yesFlag:      false,
+			templateFlag: "git",
+			enableFlag:   "",
+			expected:     []string{"commit-parser", "tag-manager"},
+		},
+		{
+			name:         "template automation",
+			ctx:          &ProjectContext{},
+			yesFlag:      false,
+			templateFlag: "automation",
+			enableFlag:   "",
+			expected:     []string{"commit-parser", "tag-manager", "changelog-generator"},
+		},
+		{
+			name:         "template strict",
+			ctx:          &ProjectContext{},
+			yesFlag:      false,
+			templateFlag: "strict",
+			enableFlag:   "",
+			expected:     []string{"commit-parser", "tag-manager", "version-validator", "release-gate"},
+		},
+		{
+			name:         "invalid template returns error",
+			ctx:          &ProjectContext{},
+			yesFlag:      false,
+			templateFlag: "invalid-template",
+			enableFlag:   "",
+			expectError:  true,
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := determinePlugins(tt.ctx, tt.yesFlag, tt.enableFlag)
+			got, err := determinePlugins(tt.ctx, tt.yesFlag, tt.templateFlag, tt.enableFlag)
+			if tt.expectError {
+				if err == nil {
+					t.Fatalf("expected error, got nil")
+				}
+				return
+			}
 			if err != nil {
 				t.Fatalf("unexpected error: %v", err)
 			}
 
 			if len(got) != len(tt.expected) {
-				t.Errorf("expected %d plugins, got %d", len(tt.expected), len(got))
+				t.Errorf("expected %d plugins, got %d: %v", len(tt.expected), len(got), got)
 				return
 			}
 
@@ -477,5 +639,260 @@ func TestPluralize(t *testing.T) {
 				t.Errorf("expected %q, got %q", tt.expected, got)
 			}
 		})
+	}
+}
+
+func TestCreateConfigFile(t *testing.T) {
+	t.Run("creates new config file", func(t *testing.T) {
+		tmp := t.TempDir()
+		t.Chdir(tmp)
+
+		created, err := createConfigFile([]string{"commit-parser"}, false)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if !created {
+			t.Error("expected file to be created")
+		}
+
+		// Verify file exists
+		if _, err := os.Stat(".sley.yaml"); os.IsNotExist(err) {
+			t.Error("expected .sley.yaml to exist")
+		}
+	})
+
+	t.Run("force overwrites existing file", func(t *testing.T) {
+		tmp := t.TempDir()
+		t.Chdir(tmp)
+
+		// Create existing config
+		if err := os.WriteFile(".sley.yaml", []byte("old: config\n"), 0600); err != nil {
+			t.Fatal(err)
+		}
+
+		created, err := createConfigFile([]string{"commit-parser", "tag-manager"}, true)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if !created {
+			t.Error("expected file to be created with force")
+		}
+
+		// Verify file was overwritten
+		data, _ := os.ReadFile(".sley.yaml")
+		if strings.Contains(string(data), "old: config") {
+			t.Error("expected config to be overwritten")
+		}
+	})
+
+	// Note: The "skips existing file without force in non-interactive" path
+	// is tested via CLI tests using --yes flag which avoids interactive prompts
+}
+
+func TestPrintVersionOnlySuccess(t *testing.T) {
+	t.Run("prints with valid version", func(t *testing.T) {
+		tmp := t.TempDir()
+		versionPath := filepath.Join(tmp, ".version")
+		if err := os.WriteFile(versionPath, []byte("1.2.3\n"), 0600); err != nil {
+			t.Fatal(err)
+		}
+
+		output, _ := testutils.CaptureStdout(func() {
+			printVersionOnlySuccess(versionPath)
+		})
+
+		if !strings.Contains(output, "1.2.3") {
+			t.Errorf("expected version in output, got: %s", output)
+		}
+	})
+
+	t.Run("prints without version on error", func(t *testing.T) {
+		tmp := t.TempDir()
+		versionPath := filepath.Join(tmp, ".version")
+		// Create file with invalid version
+		if err := os.WriteFile(versionPath, []byte("invalid\n"), 0600); err != nil {
+			t.Fatal(err)
+		}
+
+		output, _ := testutils.CaptureStdout(func() {
+			printVersionOnlySuccess(versionPath)
+		})
+
+		if !strings.Contains(output, "Initialized") {
+			t.Errorf("expected initialized message, got: %s", output)
+		}
+	})
+}
+
+func TestPrintSuccessSummary(t *testing.T) {
+	t.Run("prints all messages when both created", func(t *testing.T) {
+		tmp := t.TempDir()
+		versionPath := filepath.Join(tmp, ".version")
+		if err := os.WriteFile(versionPath, []byte("1.0.0\n"), 0600); err != nil {
+			t.Fatal(err)
+		}
+
+		ctx := &ProjectContext{IsGitRepo: true}
+		plugins := []string{"commit-parser", "tag-manager"}
+
+		output, _ := testutils.CaptureStdout(func() {
+			printSuccessSummary(versionPath, true, true, plugins, ctx)
+		})
+
+		if !strings.Contains(output, "1.0.0") {
+			t.Error("expected version in output")
+		}
+		if !strings.Contains(output, "2 plugins enabled") {
+			t.Error("expected plugins count in output")
+		}
+		if !strings.Contains(output, "Next steps") {
+			t.Error("expected next steps in output")
+		}
+	})
+
+	t.Run("prints version created without config", func(t *testing.T) {
+		tmp := t.TempDir()
+		versionPath := filepath.Join(tmp, ".version")
+		if err := os.WriteFile(versionPath, []byte("2.0.0\n"), 0600); err != nil {
+			t.Fatal(err)
+		}
+
+		ctx := &ProjectContext{IsGitRepo: false}
+
+		output, _ := testutils.CaptureStdout(func() {
+			printSuccessSummary(versionPath, true, false, nil, ctx)
+		})
+
+		if !strings.Contains(output, "2.0.0") {
+			t.Error("expected version in output")
+		}
+	})
+
+	t.Run("handles version read error gracefully", func(t *testing.T) {
+		tmp := t.TempDir()
+		versionPath := filepath.Join(tmp, ".version")
+		// Create file with invalid content
+		if err := os.WriteFile(versionPath, []byte("invalid\n"), 0600); err != nil {
+			t.Fatal(err)
+		}
+
+		ctx := &ProjectContext{}
+
+		output, _ := testutils.CaptureStdout(func() {
+			printSuccessSummary(versionPath, true, false, nil, ctx)
+		})
+
+		// Should still print created message (without version)
+		if !strings.Contains(output, "Created") {
+			t.Error("expected created message in output")
+		}
+	})
+}
+
+func TestInitializeVersionFileWithMigration(t *testing.T) {
+	t.Run("uses migrated version", func(t *testing.T) {
+		tmp := t.TempDir()
+		versionPath := filepath.Join(tmp, ".version")
+
+		created, err := initializeVersionFileWithMigration(versionPath, "5.0.0")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if !created {
+			t.Error("expected file to be created")
+		}
+
+		data, _ := os.ReadFile(versionPath)
+		if string(data) != "5.0.0\n" {
+			t.Errorf("expected version 5.0.0, got %q", string(data))
+		}
+	})
+
+	t.Run("uses default when no migration version", func(t *testing.T) {
+		tmp := t.TempDir()
+		versionPath := filepath.Join(tmp, ".version")
+
+		created, err := initializeVersionFileWithMigration(versionPath, "")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if !created {
+			t.Error("expected file to be created")
+		}
+
+		// Should have default version (0.1.0 or from git tag)
+		data, _ := os.ReadFile(versionPath)
+		if string(data) == "" {
+			t.Error("expected version to be written")
+		}
+	})
+
+	t.Run("returns false for existing valid file", func(t *testing.T) {
+		tmp := t.TempDir()
+		versionPath := filepath.Join(tmp, ".version")
+		if err := os.WriteFile(versionPath, []byte("1.0.0\n"), 0600); err != nil {
+			t.Fatal(err)
+		}
+
+		created, err := initializeVersionFileWithMigration(versionPath, "2.0.0")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if created {
+			t.Error("expected file to not be recreated")
+		}
+
+		// Verify original content unchanged
+		data, _ := os.ReadFile(versionPath)
+		if string(data) != "1.0.0\n" {
+			t.Errorf("expected original version, got %q", string(data))
+		}
+	})
+
+	t.Run("returns error for existing invalid file", func(t *testing.T) {
+		tmp := t.TempDir()
+		versionPath := filepath.Join(tmp, ".version")
+		if err := os.WriteFile(versionPath, []byte("invalid\n"), 0600); err != nil {
+			t.Fatal(err)
+		}
+
+		_, err := initializeVersionFileWithMigration(versionPath, "2.0.0")
+		if err == nil {
+			t.Fatal("expected error for invalid existing file")
+		}
+		if !strings.Contains(err.Error(), "failed to read version file") {
+			t.Errorf("expected read error, got: %v", err)
+		}
+	})
+}
+
+// Note: TestDeterminePlugins_NonInteractive is not tested directly here
+// because the test environment may appear interactive.
+// The non-interactive fallback path is covered by CLI tests using
+// --yes, --template, and --enable flags which bypass the interactive prompt.
+
+func TestCLI_InitCommand_NoPluginsSelected(t *testing.T) {
+	// This test verifies behavior when plugins list is empty
+	// which happens when user cancels interactive prompt
+	tmp := t.TempDir()
+	versionPath := filepath.Join(tmp, ".version")
+
+	t.Chdir(tmp)
+
+	cfg := &config.Config{Path: versionPath}
+	appCli := testutils.BuildCLIForTests(cfg.Path, []*cli.Command{Run()})
+
+	// Using --enable with empty value won't trigger this path
+	// But --yes without other flags will use defaults
+	err := appCli.Run(context.Background(), []string{
+		"sley", "init", "--enable", "",
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// With empty enable flag, should create version but skip config
+	if _, err := os.Stat(versionPath); os.IsNotExist(err) {
+		t.Error("expected .version to be created")
 	}
 }

--- a/cmd/sley/initcmd/templates.go
+++ b/cmd/sley/initcmd/templates.go
@@ -1,0 +1,78 @@
+package initcmd
+
+import (
+	"fmt"
+	"slices"
+	"strings"
+)
+
+// Template represents a pre-configured set of plugins for common use cases.
+type Template struct {
+	Name        string
+	Description string
+	Plugins     []string
+}
+
+// AllTemplates returns all available templates.
+func AllTemplates() []Template {
+	return []Template{
+		{
+			Name:        "basic",
+			Description: "Minimal setup with commit analysis only",
+			Plugins:     []string{"commit-parser"},
+		},
+		{
+			Name:        "git",
+			Description: "Standard git workflow with tagging",
+			Plugins:     []string{"commit-parser", "tag-manager"},
+		},
+		{
+			Name:        "automation",
+			Description: "Automated releases with changelog generation",
+			Plugins:     []string{"commit-parser", "tag-manager", "changelog-generator"},
+		},
+		{
+			Name:        "strict",
+			Description: "Enforced policies with release gates",
+			Plugins:     []string{"commit-parser", "tag-manager", "version-validator", "release-gate"},
+		},
+		{
+			Name:        "full",
+			Description: "All plugins enabled for maximum automation",
+			Plugins: []string{
+				"commit-parser",
+				"tag-manager",
+				"version-validator",
+				"dependency-check",
+				"changelog-generator",
+				"release-gate",
+				"audit-log",
+			},
+		},
+	}
+}
+
+// TemplateNames returns the names of all available templates.
+func TemplateNames() []string {
+	templates := AllTemplates()
+	names := make([]string, len(templates))
+	for i, t := range templates {
+		names[i] = t.Name
+	}
+	return names
+}
+
+// GetTemplate returns the template with the given name, or an error if not found.
+func GetTemplate(name string) (*Template, error) {
+	for _, t := range AllTemplates() {
+		if t.Name == name {
+			return &t, nil
+		}
+	}
+	return nil, fmt.Errorf("unknown template %q (available: %s)", name, strings.Join(TemplateNames(), ", "))
+}
+
+// IsValidTemplate checks if the given name is a valid template.
+func IsValidTemplate(name string) bool {
+	return slices.Contains(TemplateNames(), name)
+}

--- a/cmd/sley/initcmd/templates_test.go
+++ b/cmd/sley/initcmd/templates_test.go
@@ -1,0 +1,151 @@
+package initcmd
+
+import (
+	"testing"
+)
+
+func TestAllTemplates(t *testing.T) {
+	templates := AllTemplates()
+
+	if len(templates) == 0 {
+		t.Error("expected at least one template")
+	}
+
+	// Verify each template has required fields
+	for _, tmpl := range templates {
+		if tmpl.Name == "" {
+			t.Error("template has empty name")
+		}
+		if tmpl.Description == "" {
+			t.Errorf("template %q has empty description", tmpl.Name)
+		}
+		if len(tmpl.Plugins) == 0 {
+			t.Errorf("template %q has no plugins", tmpl.Name)
+		}
+	}
+}
+
+func TestTemplateNames(t *testing.T) {
+	names := TemplateNames()
+
+	expectedNames := []string{"basic", "git", "automation", "strict", "full"}
+	if len(names) != len(expectedNames) {
+		t.Errorf("expected %d templates, got %d", len(expectedNames), len(names))
+	}
+
+	for i, expected := range expectedNames {
+		if names[i] != expected {
+			t.Errorf("template[%d]: expected %q, got %q", i, expected, names[i])
+		}
+	}
+}
+
+func TestGetTemplate(t *testing.T) {
+	tests := []struct {
+		name            string
+		templateName    string
+		expectedPlugins []string
+		expectError     bool
+	}{
+		{
+			name:            "basic template",
+			templateName:    "basic",
+			expectedPlugins: []string{"commit-parser"},
+		},
+		{
+			name:            "git template",
+			templateName:    "git",
+			expectedPlugins: []string{"commit-parser", "tag-manager"},
+		},
+		{
+			name:            "automation template",
+			templateName:    "automation",
+			expectedPlugins: []string{"commit-parser", "tag-manager", "changelog-generator"},
+		},
+		{
+			name:            "strict template",
+			templateName:    "strict",
+			expectedPlugins: []string{"commit-parser", "tag-manager", "version-validator", "release-gate"},
+		},
+		{
+			name:         "full template has 7 plugins",
+			templateName: "full",
+			expectedPlugins: []string{
+				"commit-parser",
+				"tag-manager",
+				"version-validator",
+				"dependency-check",
+				"changelog-generator",
+				"release-gate",
+				"audit-log",
+			},
+		},
+		{
+			name:         "unknown template returns error",
+			templateName: "unknown",
+			expectError:  true,
+		},
+		{
+			name:         "empty template name returns error",
+			templateName: "",
+			expectError:  true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tmpl, err := GetTemplate(tt.templateName)
+
+			if tt.expectError {
+				if err == nil {
+					t.Fatal("expected error, got nil")
+				}
+				return
+			}
+
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+
+			if tmpl.Name != tt.templateName {
+				t.Errorf("expected template name %q, got %q", tt.templateName, tmpl.Name)
+			}
+
+			if len(tmpl.Plugins) != len(tt.expectedPlugins) {
+				t.Errorf("expected %d plugins, got %d: %v", len(tt.expectedPlugins), len(tmpl.Plugins), tmpl.Plugins)
+				return
+			}
+
+			for i, expected := range tt.expectedPlugins {
+				if tmpl.Plugins[i] != expected {
+					t.Errorf("plugin[%d]: expected %q, got %q", i, expected, tmpl.Plugins[i])
+				}
+			}
+		})
+	}
+}
+
+func TestIsValidTemplate(t *testing.T) {
+	tests := []struct {
+		name     string
+		expected bool
+	}{
+		{"basic", true},
+		{"git", true},
+		{"automation", true},
+		{"strict", true},
+		{"full", true},
+		{"unknown", false},
+		{"", false},
+		{"BASIC", false}, // case-sensitive
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := IsValidTemplate(tt.name)
+			if got != tt.expected {
+				t.Errorf("IsValidTemplate(%q): expected %v, got %v", tt.name, tt.expected, got)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Add support for pre-configured templates that bundle common plugin combinations:

- basic: commit-parser only
- git: commit-parser, tag-manager
- automation: commit-parser, tag-manager, changelog-generator
- strict: commit-parser, tag-manager, version-validator, release-gate
- full: all plugins enabled

<!-- GitButler Footer Boundary Top -->
---
This is **part 2 of 4 in a stack** made with GitButler:
- <kbd>&nbsp;4&nbsp;</kbd> #68 
- <kbd>&nbsp;3&nbsp;</kbd> #67 
- <kbd>&nbsp;2&nbsp;</kbd> #66 👈 
- <kbd>&nbsp;1&nbsp;</kbd> #65 
<!-- GitButler Footer Boundary Bottom -->

