### PR TITLE
docs: update doctor and init command descriptions

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,8 +155,8 @@ COMMANDS:
    bump              Bump semantic version (patch, minor, major)
    changelog         Manage changelog files
    pre               Set pre-release label (e.g., alpha, beta.1)
-   doctor, validate  Validate the .version file
-   init              Initialize a .version file (auto-detects Git tag or starts from 0.1.0)
+   doctor, validate  Validate .version file(s) and configuration
+   init              Initialize .version file and .sley.yaml configuration
    extension         Manage extensions for sley
    modules, mods     Manage and discover modules in workspace
    help, h           Shows a list of commands or help for one command

--- a/cmd/sley/doctorcmd/doctorcmd.go
+++ b/cmd/sley/doctorcmd/doctorcmd.go
@@ -20,7 +20,7 @@ func Run(cfg *config.Config) *cli.Command {
 	return &cli.Command{
 		Name:      "doctor",
 		Aliases:   []string{"validate"},
-		Usage:     "Validate the .version file",
+		Usage:     "Validate .version file(s) and configuration",
 		UsageText: "sley doctor [--all] [--module name] [--format text|json|table]",
 		Flags:     flags.MultiModuleFlags(),
 		Action: func(ctx context.Context, cmd *cli.Command) error {


### PR DESCRIPTION
- doctor: reflect multi-module validation support
- init: align README with actual command description