### PR TITLE
fix(clix): skip TUI module selection for read-only commands

### DIFF
--- a/cmd/sley/doctorcmd/doctorcmd.go
+++ b/cmd/sley/doctorcmd/doctorcmd.go
@@ -32,7 +32,8 @@ func Run(cfg *config.Config) *cli.Command {
 // runDoctorCmd checks that the .version file is valid.
 func runDoctorCmd(ctx context.Context, cmd *cli.Command, cfg *config.Config) error {
 	// Get execution context to determine single vs multi-module mode
-	execCtx, err := clix.GetExecutionContext(ctx, cmd, cfg)
+	// Use WithDefaultAll since doctor is a read-only command - no need for TUI prompt
+	execCtx, err := clix.GetExecutionContext(ctx, cmd, cfg, clix.WithDefaultAll())
 	if err != nil {
 		return err
 	}

--- a/cmd/sley/showcmd/showcmd.go
+++ b/cmd/sley/showcmd/showcmd.go
@@ -31,7 +31,8 @@ func Run(cfg *config.Config) *cli.Command {
 // runShowCmd prints the current version.
 func runShowCmd(ctx context.Context, cmd *cli.Command, cfg *config.Config) error {
 	// Get execution context to determine single vs multi-module mode
-	execCtx, err := clix.GetExecutionContext(ctx, cmd, cfg)
+	// Use WithDefaultAll since show is a read-only command - no need for TUI prompt
+	execCtx, err := clix.GetExecutionContext(ctx, cmd, cfg, clix.WithDefaultAll())
 	if err != nil {
 		return err
 	}

--- a/internal/clix/execution_context_test.go
+++ b/internal/clix/execution_context_test.go
@@ -784,7 +784,7 @@ func TestGetMultiModuleContext_NoModulesFound(t *testing.T) {
 	}
 
 	ctx := context.Background()
-	_, ctxErr := getMultiModuleContext(ctx, cmd, cfg, false)
+	_, ctxErr := getMultiModuleContext(ctx, cmd, cfg, &executionOptions{}, false)
 	if ctxErr == nil {
 		t.Fatal("expected error for no modules found")
 	}
@@ -843,7 +843,7 @@ func TestGetMultiModuleContext_NonInteractive(t *testing.T) {
 	}
 
 	ctx := context.Background()
-	execCtx, err := getMultiModuleContext(ctx, cmd, cfg, false)
+	execCtx, err := getMultiModuleContext(ctx, cmd, cfg, &executionOptions{}, false)
 	if err != nil {
 		t.Fatalf("getMultiModuleContext() error = %v", err)
 	}


### PR DESCRIPTION
## Summary

- Add `ExecutionOption` functional options pattern to `clix.GetExecutionContext`
- Add `WithDefaultAll()` option to skip TUI and default to all modules
- Apply to `show` and `doctor` commands (read-only operations)
- Keep TUI prompts for mutating commands (`bump`, `set`, `pre`)