### PR TITLE
feat(clix): add WithDefaultAll option for read-only commands

### DIFF
--- a/cmd/sley/showcmd/showcmd_test.go
+++ b/cmd/sley/showcmd/showcmd_test.go
@@ -47,6 +47,7 @@ func TestCLI_ShowCommand_Strict_MissingFile(t *testing.T) {
 		err := appCli.Run(context.Background(), []string{"sley", "show", "--strict"})
 		if err != nil {
 			fmt.Fprintln(os.Stderr, err)
+			os.Exit(1) // Exit with non-zero status to signal error to parent process
 		}
 		return
 	}

--- a/internal/clix/clix.go
+++ b/internal/clix/clix.go
@@ -2,7 +2,6 @@ package clix
 
 import (
 	"context"
-	stderrors "errors"
 	"fmt"
 	"os"
 
@@ -20,7 +19,7 @@ var FromCommandFn = fromCommand
 // fromCommand extracts the --path and --strict flags from a cli.Command,
 // and passes them to GetOrInitVersionFile.
 func fromCommand(cmd *cli.Command) (bool, error) {
-	return getOrInitVersionFile(cmd.String("path"), cmd.Bool("strict"))
+	return GetOrInitVersionFile(cmd.String("path"), cmd.Bool("strict"))
 }
 
 // GetOrInitVersionFile initializes the version file at the given path
@@ -41,22 +40,6 @@ func GetOrInitVersionFile(path string, strict bool) (bool, error) {
 	}
 	if created {
 		fmt.Printf("Auto-initialized %s with default version\n", path)
-	}
-	return created, nil
-}
-
-// getOrInitVersionFile is the internal implementation that wraps errors for CLI display.
-//
-// Deprecated: Use GetOrInitVersionFile and handle errors at the CLI layer.
-func getOrInitVersionFile(path string, strict bool) (bool, error) {
-	created, err := GetOrInitVersionFile(path, strict)
-	if err != nil {
-		// Convert typed errors to CLI exits for backward compatibility
-		var vfErr *apperrors.VersionFileNotFoundError
-		if stderrors.As(err, &vfErr) {
-			return false, cli.Exit(vfErr.Error(), 1)
-		}
-		return false, err
 	}
 	return created, nil
 }

--- a/internal/clix/clix_test.go
+++ b/internal/clix/clix_test.go
@@ -19,7 +19,7 @@ func TestGetOrInitVersionFile(t *testing.T) {
 		tmpDir := t.TempDir()
 		tmpFile := testutils.WriteTempVersionFile(t, tmpDir, "0.1.0")
 
-		created, err := getOrInitVersionFile(tmpFile, true)
+		created, err := GetOrInitVersionFile(tmpFile, true)
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -31,7 +31,7 @@ func TestGetOrInitVersionFile(t *testing.T) {
 	t.Run("strict=true and file missing", func(t *testing.T) {
 		missingPath := filepath.Join(t.TempDir(), "missing.version")
 
-		created, err := getOrInitVersionFile(missingPath, true)
+		created, err := GetOrInitVersionFile(missingPath, true)
 		if err == nil {
 			t.Fatal("expected error, got nil")
 		}
@@ -44,7 +44,7 @@ func TestGetOrInitVersionFile(t *testing.T) {
 		tmpDir := t.TempDir()
 		targetPath := filepath.Join(tmpDir, ".version")
 
-		created, err := getOrInitVersionFile(targetPath, false)
+		created, err := GetOrInitVersionFile(targetPath, false)
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -70,7 +70,7 @@ func TestGetOrInitVersionFile_InitError(t *testing.T) {
 
 	targetPath := "/test/.version"
 
-	created, err := getOrInitVersionFile(targetPath, false)
+	created, err := GetOrInitVersionFile(targetPath, false)
 	if err == nil {
 		t.Fatal("expected error, got nil")
 	}


### PR DESCRIPTION
## Summary

- Add `ExecutionOption` functional options pattern to `clix.GetExecutionContext`
- Add `WithDefaultAll()` option to skip TUI and default to all modules
- Useful for read-only commands that don't need interactive selection
