### PR TITLE
feat(printer): add styled output for validation results

### DIFF
--- a/cmd/sley/cli.go
+++ b/cmd/sley/cli.go
@@ -15,6 +15,7 @@ import (
 	"github.com/indaco/sley/cmd/sley/showcmd"
 	"github.com/indaco/sley/internal/config"
 	"github.com/indaco/sley/internal/console"
+	"github.com/indaco/sley/internal/printer"
 	"github.com/indaco/sley/internal/version"
 	"github.com/urfave/cli/v3"
 )
@@ -25,9 +26,10 @@ var noColorFlag bool
 // configuring all subcommands and flags for the sley cli.
 func newCLI(cfg *config.Config) *cli.Command {
 	return &cli.Command{
-		Name:    "sley",
-		Version: fmt.Sprintf("v%s", version.GetVersion()),
-		Usage:   "Version orchestrator for semantic versioning",
+		Name:                  "sley",
+		Version:               fmt.Sprintf("v%s", version.GetVersion()),
+		Usage:                 "Version orchestrator for semantic versioning",
+		EnableShellCompletion: true,
 		Flags: []cli.Flag{
 			&cli.StringFlag{
 				Name:    "path",
@@ -48,6 +50,7 @@ func newCLI(cfg *config.Config) *cli.Command {
 		},
 		Before: func(ctx context.Context, cmd *cli.Command) (context.Context, error) {
 			console.SetNoColor(noColorFlag)
+			printer.SetNoColor(noColorFlag)
 			return ctx, nil
 		},
 		Commands: []*cli.Command{

--- a/internal/printer/printer.go
+++ b/internal/printer/printer.go
@@ -2,19 +2,38 @@ package printer
 
 import (
 	"fmt"
+	"os"
 
 	"github.com/charmbracelet/lipgloss"
+	"github.com/muesli/termenv"
 )
 
-// Style definitions for consistent console output across the application.
 var (
+	// noColor is set by SetNoColor and controls whether colors are rendered.
+	noColor bool
+
+	// Style definitions for consistent console output across the application.
 	faintStyle   = lipgloss.NewStyle().Faint(true)
 	boldStyle    = lipgloss.NewStyle().Bold(true)
 	successStyle = lipgloss.NewStyle().Foreground(lipgloss.Color("2")) // Green
 	errorStyle   = lipgloss.NewStyle().Foreground(lipgloss.Color("1")) // Red
 	warningStyle = lipgloss.NewStyle().Foreground(lipgloss.Color("3")) // Yellow
 	infoStyle    = lipgloss.NewStyle().Foreground(lipgloss.Color("6")) // Cyan
+
+	// Combined styles for status badges
+	successBadgeStyle = lipgloss.NewStyle().Bold(true).Foreground(lipgloss.Color("2")) // Bold green
+	errorBadgeStyle   = lipgloss.NewStyle().Bold(true).Foreground(lipgloss.Color("1")) // Bold red
+	warningBadgeStyle = lipgloss.NewStyle().Bold(true).Foreground(lipgloss.Color("3")) // Bold yellow
 )
+
+// SetNoColor controls whether the printer uses colors.
+// This respects the --no-color flag and NO_COLOR environment variable.
+func SetNoColor(disabled bool) {
+	noColor = disabled
+	if noColor || os.Getenv("NO_COLOR") != "" {
+		lipgloss.SetColorProfile(termenv.Ascii)
+	}
+}
 
 // Render functions return styled strings without printing.
 
@@ -78,4 +97,46 @@ func PrintWarning(text string) {
 // PrintInfo prints text with info (cyan) styling.
 func PrintInfo(text string) {
 	fmt.Println(Info(text))
+}
+
+// SuccessBadge returns a bold, green styled badge.
+func SuccessBadge(text string) string {
+	return successBadgeStyle.Render(text)
+}
+
+// ErrorBadge returns a bold, red styled badge.
+func ErrorBadge(text string) string {
+	return errorBadgeStyle.Render(text)
+}
+
+// WarningBadge returns a bold, yellow styled badge.
+func WarningBadge(text string) string {
+	return warningBadgeStyle.Render(text)
+}
+
+// FormatValidationPass formats a validation result with PASS status.
+// Symbol and badge are bold green, category is normal, message is faint.
+func FormatValidationPass(symbol, badge, category, message string) string {
+	styledSymbol := successBadgeStyle.Render(symbol)
+	styledBadge := successBadgeStyle.Render(badge)
+	styledMessage := faintStyle.Render(message)
+	return fmt.Sprintf("%s %s %s: %s", styledSymbol, styledBadge, category, styledMessage)
+}
+
+// FormatValidationFail formats a validation result with FAIL status.
+// Symbol and badge are bold red, category is normal, message is faint.
+func FormatValidationFail(symbol, badge, category, message string) string {
+	styledSymbol := errorBadgeStyle.Render(symbol)
+	styledBadge := errorBadgeStyle.Render(badge)
+	styledMessage := faintStyle.Render(message)
+	return fmt.Sprintf("%s %s %s: %s", styledSymbol, styledBadge, category, styledMessage)
+}
+
+// FormatValidationWarn formats a validation result with WARN status.
+// Symbol and badge are bold yellow, category is normal, message is faint.
+func FormatValidationWarn(symbol, badge, category, message string) string {
+	styledSymbol := warningBadgeStyle.Render(symbol)
+	styledBadge := warningBadgeStyle.Render(badge)
+	styledMessage := faintStyle.Render(message)
+	return fmt.Sprintf("%s %s %s: %s", styledSymbol, styledBadge, category, styledMessage)
 }

--- a/internal/printer/printer_test.go
+++ b/internal/printer/printer_test.go
@@ -120,3 +120,105 @@ func TestEmptyInput(t *testing.T) {
 		})
 	}
 }
+
+// TestBadgeFunctions verifies that badge functions return styled strings.
+func TestBadgeFunctions(t *testing.T) {
+	tests := []struct {
+		name     string
+		function func(string) string
+		input    string
+	}{
+		{"SuccessBadge", SuccessBadge, "[PASS]"},
+		{"ErrorBadge", ErrorBadge, "[FAIL]"},
+		{"WarningBadge", WarningBadge, "[WARN]"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := tt.function(tt.input)
+
+			// Verify result is not empty
+			if result == "" {
+				t.Errorf("%s() returned empty string", tt.name)
+			}
+
+			// Verify result contains the original text
+			if !strings.Contains(result, tt.input) {
+				t.Errorf("%s() result does not contain input text. got %q, want to contain %q", tt.name, result, tt.input)
+			}
+		})
+	}
+}
+
+// TestValidationFormatFunctions verifies validation formatting functions.
+func TestValidationFormatFunctions(t *testing.T) {
+	tests := []struct {
+		name     string
+		function func(string, string, string, string) string
+		symbol   string
+		badge    string
+		category string
+		message  string
+	}{
+		{
+			name:     "FormatValidationPass",
+			function: FormatValidationPass,
+			symbol:   "✓",
+			badge:    "[PASS]",
+			category: "YAML Syntax",
+			message:  "Configuration file is valid YAML",
+		},
+		{
+			name:     "FormatValidationFail",
+			function: FormatValidationFail,
+			symbol:   "✗",
+			badge:    "[FAIL]",
+			category: "Plugin: audit-log",
+			message:  "Invalid format 'xml': must be 'json' or 'yaml'",
+		},
+		{
+			name:     "FormatValidationWarn",
+			function: FormatValidationWarn,
+			symbol:   "⚠",
+			badge:    "[WARN]",
+			category: "Plugin: tag-manager",
+			message:  "Tag prefix 'v' is valid",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := tt.function(tt.symbol, tt.badge, tt.category, tt.message)
+
+			// Verify result is not empty
+			if result == "" {
+				t.Errorf("%s() returned empty string", tt.name)
+			}
+
+			// Verify result contains all components
+			if !strings.Contains(result, tt.symbol) {
+				t.Errorf("%s() result does not contain symbol. got %q, want to contain %q", tt.name, result, tt.symbol)
+			}
+			if !strings.Contains(result, tt.badge) {
+				t.Errorf("%s() result does not contain badge. got %q, want to contain %q", tt.name, result, tt.badge)
+			}
+			if !strings.Contains(result, tt.category) {
+				t.Errorf("%s() result does not contain category. got %q, want to contain %q", tt.name, result, tt.category)
+			}
+			if !strings.Contains(result, tt.message) {
+				t.Errorf("%s() result does not contain message. got %q, want to contain %q", tt.name, result, tt.message)
+			}
+
+			// Verify the format follows the expected pattern: "symbol badge category: message"
+			// We check that category comes before message
+			categoryIndex := strings.Index(result, tt.category)
+			messageIndex := strings.Index(result, tt.message)
+			if categoryIndex == -1 || messageIndex == -1 {
+				t.Fatalf("%s() missing category or message in result", tt.name)
+			}
+			if categoryIndex >= messageIndex {
+				t.Errorf("%s() category should come before message", tt.name)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

- Add bold colored badges for [PASS], [FAIL], [WARN] status
- Add validation formatting with colored symbols, normal category, faint message
- Update workspace formatter with styled module output
- Respect --no-color flag across all styled output