### PR TITLE
feat(doctor): add configuration file validation

### DIFF
--- a/cmd/sley/doctorcmd/doctorcmd.go
+++ b/cmd/sley/doctorcmd/doctorcmd.go
@@ -2,7 +2,10 @@ package doctorcmd
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
+	"os"
+	"strings"
 
 	"github.com/indaco/sley/cmd/sley/flags"
 	"github.com/indaco/sley/internal/clix"
@@ -29,8 +32,13 @@ func Run(cfg *config.Config) *cli.Command {
 	}
 }
 
-// runDoctorCmd checks that the .version file is valid.
+// runDoctorCmd validates both configuration and .version files.
 func runDoctorCmd(ctx context.Context, cmd *cli.Command, cfg *config.Config) error {
+	// First, validate the configuration file
+	if err := validateConfiguration(cmd, cfg); err != nil {
+		return err
+	}
+
 	// Get execution context to determine single vs multi-module mode
 	// Use WithDefaultAll since doctor is a read-only command - no need for TUI prompt
 	execCtx, err := clix.GetExecutionContext(ctx, cmd, cfg, clix.WithDefaultAll())
@@ -45,6 +53,142 @@ func runDoctorCmd(ctx context.Context, cmd *cli.Command, cfg *config.Config) err
 
 	// Handle multi-module mode
 	return runMultiModuleValidate(ctx, cmd, execCtx)
+}
+
+// validateConfiguration validates the .sley.yaml configuration file.
+func validateConfiguration(cmd *cli.Command, cfg *config.Config) error {
+	// Determine config file path and root directory
+	configPath := ".sley.yaml"
+	rootDir, err := os.Getwd()
+	if err != nil {
+		rootDir = "."
+	}
+
+	// Check if config file exists
+	if _, err := os.Stat(configPath); err != nil {
+		if os.IsNotExist(err) {
+			configPath = "" // No config file
+		}
+	}
+
+	// Create validator
+	fs := core.NewOSFileSystem()
+	validator := config.NewValidator(fs, cfg, configPath, rootDir)
+
+	// Run validation
+	results, err := validator.Validate()
+	if err != nil {
+		return fmt.Errorf("validation failed: %w", err)
+	}
+
+	// Format and display results
+	format := cmd.String("format")
+	quiet := cmd.Bool("quiet")
+
+	if quiet {
+		// In quiet mode, only show summary
+		printConfigValidationSummary(results)
+	} else {
+		printConfigValidationResults(results, format)
+	}
+
+	// Return error if any validation failed
+	if config.HasErrors(results) {
+		return fmt.Errorf("configuration validation failed with %d error(s)", config.ErrorCount(results))
+	}
+
+	return nil
+}
+
+// printConfigValidationResults prints detailed validation results.
+func printConfigValidationResults(results []config.ValidationResult, format string) {
+	if format == "json" {
+		printConfigValidationJSON(results)
+		return
+	}
+
+	// Text/table format
+	fmt.Println() // Empty line before header
+	printer.PrintInfo("Configuration Validation:")
+	printer.PrintFaint(strings.Repeat("-", 70))
+
+	for _, result := range results {
+		var formatted string
+		switch {
+		case !result.Passed:
+			// FAIL - bold red symbol and badge, normal category, faint message
+			formatted = printer.FormatValidationFail("✗", "[FAIL]", result.Category, result.Message)
+		case result.Warning:
+			// WARN - bold yellow symbol and badge, normal category, faint message
+			formatted = printer.FormatValidationWarn("⚠", "[WARN]", result.Category, result.Message)
+		default:
+			// PASS - bold green symbol and badge, normal category, faint message
+			formatted = printer.FormatValidationPass("✓", "[PASS]", result.Category, result.Message)
+		}
+		fmt.Println(formatted)
+	}
+
+	printer.PrintFaint(strings.Repeat("-", 70))
+	printConfigValidationSummary(results)
+	fmt.Println()
+}
+
+// printConfigValidationJSON prints validation results in JSON format.
+func printConfigValidationJSON(results []config.ValidationResult) {
+	type jsonResult struct {
+		Category string `json:"category"`
+		Status   string `json:"status"`
+		Message  string `json:"message"`
+	}
+
+	output := make([]jsonResult, len(results))
+	for i, r := range results {
+		status := "pass"
+		if !r.Passed {
+			status = "fail"
+		} else if r.Warning {
+			status = "warning"
+		}
+
+		output[i] = jsonResult{
+			Category: r.Category,
+			Status:   status,
+			Message:  r.Message,
+		}
+	}
+
+	data, err := json.Marshal(map[string]any{
+		"validations": output,
+		"summary": map[string]int{
+			"total":    len(results),
+			"passed":   len(results) - config.ErrorCount(results) - config.WarningCount(results),
+			"errors":   config.ErrorCount(results),
+			"warnings": config.WarningCount(results),
+		},
+	})
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error formatting JSON: %v\n", err)
+		return
+	}
+
+	fmt.Println(string(data))
+}
+
+// printConfigValidationSummary prints a summary of validation results.
+func printConfigValidationSummary(results []config.ValidationResult) {
+	total := len(results)
+	errors := config.ErrorCount(results)
+	warnings := config.WarningCount(results)
+	passed := total - errors - warnings
+
+	switch {
+	case errors > 0:
+		printer.PrintError(fmt.Sprintf("Summary: %d passed, %d errors, %d warnings", passed, errors, warnings))
+	case warnings > 0:
+		printer.PrintWarning(fmt.Sprintf("Summary: %d passed, %d warnings", passed, warnings))
+	default:
+		printer.PrintSuccess(fmt.Sprintf("Summary: All %d validation(s) passed", total))
+	}
 }
 
 // runSingleModuleValidate handles the single-module validate operation.
@@ -88,7 +232,7 @@ func runMultiModuleValidate(ctx context.Context, cmd *cli.Command, execCtx *clix
 	format := cmd.String("format")
 	quiet := cmd.Bool("quiet")
 
-	formatter := workspace.GetFormatter(format, "Validation Summary")
+	formatter := workspace.GetFormatterWithVerb(format, "Validation Summary", "validated")
 
 	if quiet {
 		// In quiet mode, just show summary

--- a/internal/config/validator.go
+++ b/internal/config/validator.go
@@ -1,0 +1,579 @@
+package config
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+
+	"github.com/indaco/sley/internal/core"
+)
+
+// ValidationResult represents the result of a validation check.
+type ValidationResult struct {
+	// Category is the validation category (e.g., "YAML Syntax", "Plugin Config").
+	Category string
+
+	// Passed indicates if the check passed.
+	Passed bool
+
+	// Message provides details about the validation result.
+	Message string
+
+	// Warning indicates if this is a warning rather than an error.
+	Warning bool
+}
+
+// Validator validates configuration files and settings.
+type Validator struct {
+	fs          core.FileSystem
+	cfg         *Config
+	configPath  string
+	rootDir     string
+	validations []ValidationResult
+}
+
+// NewValidator creates a new configuration validator.
+// The rootDir parameter is the directory where .sley.yaml is located.
+func NewValidator(fs core.FileSystem, cfg *Config, configPath string, rootDir string) *Validator {
+	return &Validator{
+		fs:          fs,
+		cfg:         cfg,
+		configPath:  configPath,
+		rootDir:     rootDir,
+		validations: make([]ValidationResult, 0),
+	}
+}
+
+// Validate runs all validation checks and returns the results.
+func (v *Validator) Validate() ([]ValidationResult, error) {
+	// Reset validations
+	v.validations = make([]ValidationResult, 0)
+
+	// Validate YAML syntax (by trying to load it)
+	v.validateYAMLSyntax()
+
+	// Validate plugin configurations
+	v.validatePluginConfigs()
+
+	// Validate workspace configuration
+	v.validateWorkspaceConfig()
+
+	// Validate extension configurations
+	v.validateExtensionConfigs()
+
+	return v.validations, nil
+}
+
+// validateYAMLSyntax checks if the config file is valid YAML.
+func (v *Validator) validateYAMLSyntax() {
+	if v.configPath == "" {
+		// No config file, use defaults
+		v.addValidation("YAML Syntax", true, "No .sley.yaml file found, using defaults", false)
+		return
+	}
+
+	// Check if file exists
+	if _, err := v.fs.Stat(v.configPath); err != nil {
+		if os.IsNotExist(err) {
+			v.addValidation("YAML Syntax", true, "No .sley.yaml file found, using defaults", false)
+		} else {
+			v.addValidation("YAML Syntax", false, fmt.Sprintf("Failed to access config file: %v", err), false)
+		}
+		return
+	}
+
+	// If we got here, the config was successfully loaded (validated in LoadConfigFn)
+	v.addValidation("YAML Syntax", true, "Configuration file is valid YAML", false)
+}
+
+// validatePluginConfigs validates plugin-specific configurations.
+func (v *Validator) validatePluginConfigs() {
+	if v.cfg == nil || v.cfg.Plugins == nil {
+		v.addValidation("Plugin Configuration", true, "No plugin configuration found (using defaults)", false)
+		return
+	}
+
+	// Validate tag-manager plugin
+	v.validateTagManagerConfig()
+
+	// Validate version-validator plugin
+	v.validateVersionValidatorConfig()
+
+	// Validate dependency-check plugin
+	v.validateDependencyCheckConfig()
+
+	// Validate changelog-parser plugin
+	v.validateChangelogParserConfig()
+
+	// Validate changelog-generator plugin
+	v.validateChangelogGeneratorConfig()
+
+	// Validate release-gate plugin
+	v.validateReleaseGateConfig()
+
+	// Validate audit-log plugin
+	v.validateAuditLogConfig()
+}
+
+// validateTagManagerConfig validates the tag-manager plugin configuration.
+func (v *Validator) validateTagManagerConfig() {
+	if v.cfg.Plugins.TagManager == nil || !v.cfg.Plugins.TagManager.Enabled {
+		return
+	}
+
+	cfg := v.cfg.Plugins.TagManager
+
+	// Validate prefix pattern (should be a valid tag prefix)
+	prefix := cfg.GetPrefix()
+	if prefix != "" {
+		// Check if prefix contains invalid characters
+		if strings.ContainsAny(prefix, " \t\n\r/\\") {
+			v.addValidation("Plugin: tag-manager", false,
+				fmt.Sprintf("Invalid prefix '%s': contains whitespace or path separators", prefix), false)
+		} else {
+			v.addValidation("Plugin: tag-manager", true,
+				fmt.Sprintf("Tag prefix '%s' is valid", prefix), false)
+		}
+	}
+}
+
+// validateVersionValidatorConfig validates the version-validator plugin configuration.
+func (v *Validator) validateVersionValidatorConfig() {
+	if v.cfg.Plugins.VersionValidator == nil || !v.cfg.Plugins.VersionValidator.Enabled {
+		return
+	}
+
+	cfg := v.cfg.Plugins.VersionValidator
+
+	// Validate rules
+	if len(cfg.Rules) == 0 {
+		v.addValidation("Plugin: version-validator", true,
+			"Version validator enabled but no rules configured", true)
+		return
+	}
+
+	validRuleTypes := map[string]bool{
+		"pre-release-format": true,
+		"major-version-max":  true,
+		"branch-constraint":  true,
+	}
+
+	for i, rule := range cfg.Rules {
+		// Check if rule type is valid
+		if !validRuleTypes[rule.Type] {
+			v.addValidation("Plugin: version-validator", false,
+				fmt.Sprintf("Rule %d: unknown rule type '%s'", i+1, rule.Type), false)
+			continue
+		}
+
+		// Validate pattern for pre-release-format rules
+		if rule.Type == "pre-release-format" && rule.Pattern != "" {
+			if _, err := regexp.Compile(rule.Pattern); err != nil {
+				v.addValidation("Plugin: version-validator", false,
+					fmt.Sprintf("Rule %d: invalid regex pattern: %v", i+1, err), false)
+			}
+		}
+
+		// Validate branch-constraint rules
+		if rule.Type == "branch-constraint" {
+			if rule.Branch == "" {
+				v.addValidation("Plugin: version-validator", false,
+					fmt.Sprintf("Rule %d: branch-constraint requires 'branch' field", i+1), false)
+			}
+			if len(rule.Allowed) == 0 {
+				v.addValidation("Plugin: version-validator", false,
+					fmt.Sprintf("Rule %d: branch-constraint requires 'allowed' field", i+1), false)
+			}
+		}
+	}
+
+	v.addValidation("Plugin: version-validator", true,
+		fmt.Sprintf("Configured with %d validation rule(s)", len(cfg.Rules)), false)
+}
+
+// validateDependencyCheckConfig validates the dependency-check plugin configuration.
+func (v *Validator) validateDependencyCheckConfig() {
+	if v.cfg.Plugins.DependencyCheck == nil || !v.cfg.Plugins.DependencyCheck.Enabled {
+		return
+	}
+
+	cfg := v.cfg.Plugins.DependencyCheck
+
+	if len(cfg.Files) == 0 {
+		v.addValidation("Plugin: dependency-check", true,
+			"Dependency check enabled but no files configured", true)
+		return
+	}
+
+	validFormats := map[string]bool{
+		"json":  true,
+		"yaml":  true,
+		"toml":  true,
+		"raw":   true,
+		"regex": true,
+	}
+
+	for i, file := range cfg.Files {
+		// Check if file exists
+		filePath := file.Path
+		if !filepath.IsAbs(filePath) {
+			filePath = filepath.Join(v.rootDir, filePath)
+		}
+
+		if _, err := v.fs.Stat(filePath); err != nil {
+			if os.IsNotExist(err) {
+				v.addValidation("Plugin: dependency-check", false,
+					fmt.Sprintf("File %d: '%s' does not exist", i+1, file.Path), false)
+			} else {
+				v.addValidation("Plugin: dependency-check", false,
+					fmt.Sprintf("File %d: cannot access '%s': %v", i+1, file.Path, err), false)
+			}
+			continue
+		}
+
+		// Validate format
+		if !validFormats[file.Format] {
+			v.addValidation("Plugin: dependency-check", false,
+				fmt.Sprintf("File %d: unknown format '%s'", i+1, file.Format), false)
+		}
+
+		// Validate regex pattern if format is regex
+		if file.Format == "regex" && file.Pattern != "" {
+			if _, err := regexp.Compile(file.Pattern); err != nil {
+				v.addValidation("Plugin: dependency-check", false,
+					fmt.Sprintf("File %d: invalid regex pattern: %v", i+1, err), false)
+			}
+		}
+	}
+
+	v.addValidation("Plugin: dependency-check", true,
+		fmt.Sprintf("Configured to check %d file(s)", len(cfg.Files)), false)
+}
+
+// validateChangelogParserConfig validates the changelog-parser plugin configuration.
+func (v *Validator) validateChangelogParserConfig() {
+	if v.cfg.Plugins.ChangelogParser == nil || !v.cfg.Plugins.ChangelogParser.Enabled {
+		return
+	}
+
+	cfg := v.cfg.Plugins.ChangelogParser
+
+	// Validate changelog file path
+	changelogPath := cfg.Path
+	if changelogPath == "" {
+		changelogPath = "CHANGELOG.md"
+	}
+	if !filepath.IsAbs(changelogPath) {
+		changelogPath = filepath.Join(v.rootDir, changelogPath)
+	}
+
+	if _, err := v.fs.Stat(changelogPath); err != nil {
+		if os.IsNotExist(err) {
+			v.addValidation("Plugin: changelog-parser", false,
+				fmt.Sprintf("Changelog file '%s' does not exist", cfg.Path), false)
+		} else {
+			v.addValidation("Plugin: changelog-parser", false,
+				fmt.Sprintf("Cannot access changelog file: %v", err), false)
+		}
+		return
+	}
+
+	// Validate priority setting
+	if cfg.Priority != "" && cfg.Priority != "changelog" && cfg.Priority != "commits" {
+		v.addValidation("Plugin: changelog-parser", false,
+			fmt.Sprintf("Invalid priority '%s': must be 'changelog' or 'commits'", cfg.Priority), false)
+	} else {
+		v.addValidation("Plugin: changelog-parser", true,
+			fmt.Sprintf("Changelog file '%s' is accessible", cfg.Path), false)
+	}
+}
+
+// validateChangelogGeneratorConfig validates the changelog-generator plugin configuration.
+func (v *Validator) validateChangelogGeneratorConfig() {
+	if v.cfg.Plugins.ChangelogGenerator == nil || !v.cfg.Plugins.ChangelogGenerator.Enabled {
+		return
+	}
+
+	cfg := v.cfg.Plugins.ChangelogGenerator
+
+	// Validate mode
+	mode := cfg.GetMode()
+	validModes := map[string]bool{
+		"versioned": true,
+		"unified":   true,
+		"both":      true,
+	}
+	if !validModes[mode] {
+		v.addValidation("Plugin: changelog-generator", false,
+			fmt.Sprintf("Invalid mode '%s': must be 'versioned', 'unified', or 'both'", mode), false)
+	}
+
+	// Validate format
+	format := cfg.GetFormat()
+	validFormats := map[string]bool{
+		"grouped":        true,
+		"keepachangelog": true,
+	}
+	if !validFormats[format] {
+		v.addValidation("Plugin: changelog-generator", false,
+			fmt.Sprintf("Invalid format '%s': must be 'grouped' or 'keepachangelog'", format), false)
+	}
+
+	// Validate repository config
+	if cfg.Repository != nil {
+		v.validateRepositoryConfig(cfg.Repository)
+	}
+
+	// Validate exclude patterns
+	for i, pattern := range cfg.ExcludePatterns {
+		if _, err := regexp.Compile(pattern); err != nil {
+			v.addValidation("Plugin: changelog-generator", false,
+				fmt.Sprintf("Exclude pattern %d: invalid regex: %v", i+1, err), false)
+		}
+	}
+
+	v.addValidation("Plugin: changelog-generator", true,
+		fmt.Sprintf("Mode: %s, Format: %s", mode, format), false)
+}
+
+// validateRepositoryConfig validates repository configuration for changelog generator.
+func (v *Validator) validateRepositoryConfig(repo *RepositoryConfig) {
+	validProviders := map[string]bool{
+		"github":    true,
+		"gitlab":    true,
+		"codeberg":  true,
+		"gitea":     true,
+		"bitbucket": true,
+		"custom":    true,
+	}
+
+	if repo.Provider != "" && !validProviders[repo.Provider] {
+		v.addValidation("Plugin: changelog-generator", false,
+			fmt.Sprintf("Invalid repository provider '%s'", repo.Provider), false)
+	}
+
+	// If provider is custom, require host
+	if repo.Provider == "custom" && repo.Host == "" {
+		v.addValidation("Plugin: changelog-generator", false,
+			"Custom provider requires 'host' field", false)
+	}
+}
+
+// validateReleaseGateConfig validates the release-gate plugin configuration.
+func (v *Validator) validateReleaseGateConfig() {
+	if v.cfg.Plugins.ReleaseGate == nil || !v.cfg.Plugins.ReleaseGate.Enabled {
+		return
+	}
+
+	cfg := v.cfg.Plugins.ReleaseGate
+
+	// Check for conflicting branch configurations
+	if len(cfg.AllowedBranches) > 0 && len(cfg.BlockedBranches) > 0 {
+		v.addValidation("Plugin: release-gate", true,
+			"Both allowed and blocked branches configured (blocked takes precedence)", true)
+	}
+
+	v.addValidation("Plugin: release-gate", true,
+		"Release gate configuration is valid", false)
+}
+
+// validateAuditLogConfig validates the audit-log plugin configuration.
+func (v *Validator) validateAuditLogConfig() {
+	if v.cfg.Plugins.AuditLog == nil || !v.cfg.Plugins.AuditLog.Enabled {
+		return
+	}
+
+	cfg := v.cfg.Plugins.AuditLog
+
+	// Validate format
+	format := cfg.GetFormat()
+	if format != "json" && format != "yaml" {
+		v.addValidation("Plugin: audit-log", false,
+			fmt.Sprintf("Invalid format '%s': must be 'json' or 'yaml'", format), false)
+	} else {
+		v.addValidation("Plugin: audit-log", true,
+			fmt.Sprintf("Audit log format: %s", format), false)
+	}
+}
+
+// validateWorkspaceConfig validates workspace/multi-module configuration.
+func (v *Validator) validateWorkspaceConfig() {
+	if v.cfg == nil || v.cfg.Workspace == nil {
+		return
+	}
+
+	// Validate discovery configuration
+	if v.cfg.Workspace.Discovery != nil {
+		v.validateDiscoveryConfig()
+	}
+
+	// Validate explicit modules
+	if len(v.cfg.Workspace.Modules) > 0 {
+		v.validateExplicitModules()
+	}
+}
+
+// validateDiscoveryConfig validates module discovery settings.
+func (v *Validator) validateDiscoveryConfig() {
+	discovery := v.cfg.Workspace.Discovery
+
+	// Validate max depth
+	if discovery.MaxDepth != nil && *discovery.MaxDepth < 0 {
+		v.addValidation("Workspace: Discovery", false,
+			"max_depth cannot be negative", false)
+	}
+
+	// Validate exclude patterns (glob patterns)
+	for i, pattern := range discovery.Exclude {
+		// Basic validation - check for obviously invalid patterns
+		if strings.Contains(pattern, "**/**/**") {
+			v.addValidation("Workspace: Discovery", true,
+				fmt.Sprintf("Exclude pattern %d: '%s' may be overly broad", i+1, pattern), true)
+		}
+	}
+
+	v.addValidation("Workspace: Discovery", true,
+		fmt.Sprintf("Discovery configured with %d exclude pattern(s)", len(discovery.Exclude)), false)
+}
+
+// validateExplicitModules validates explicitly configured modules.
+func (v *Validator) validateExplicitModules() {
+	modules := v.cfg.Workspace.Modules
+
+	// Check for duplicate module names
+	names := make(map[string]bool)
+	for i, mod := range modules {
+		if names[mod.Name] {
+			v.addValidation("Workspace: Modules", false,
+				fmt.Sprintf("Module %d: duplicate name '%s'", i+1, mod.Name), false)
+		}
+		names[mod.Name] = true
+
+		// Check if module path exists
+		modPath := mod.Path
+		if !filepath.IsAbs(modPath) {
+			modPath = filepath.Join(v.rootDir, modPath)
+		}
+
+		if _, err := v.fs.Stat(modPath); err != nil {
+			if os.IsNotExist(err) {
+				v.addValidation("Workspace: Modules", false,
+					fmt.Sprintf("Module '%s': path '%s' does not exist", mod.Name, mod.Path), false)
+			} else {
+				v.addValidation("Workspace: Modules", false,
+					fmt.Sprintf("Module '%s': cannot access path '%s': %v", mod.Name, mod.Path, err), false)
+			}
+		}
+	}
+
+	enabledCount := 0
+	for _, mod := range modules {
+		if mod.IsEnabled() {
+			enabledCount++
+		}
+	}
+
+	v.addValidation("Workspace: Modules", true,
+		fmt.Sprintf("Configured with %d module(s) (%d enabled)", len(modules), enabledCount), false)
+}
+
+// validateExtensionConfigs validates extension configurations.
+func (v *Validator) validateExtensionConfigs() {
+	if v.cfg == nil || len(v.cfg.Extensions) == 0 {
+		return
+	}
+
+	pathErrorCount := 0
+	manifestErrorCount := 0
+
+	for i, ext := range v.cfg.Extensions {
+		// Check if extension path exists
+		extPath := ext.Path
+		if !filepath.IsAbs(extPath) {
+			extPath = filepath.Join(v.rootDir, extPath)
+		}
+
+		if _, err := v.fs.Stat(extPath); err != nil {
+			if os.IsNotExist(err) {
+				v.addValidation("Extensions", false,
+					fmt.Sprintf("Extension %d ('%s'): path '%s' does not exist", i+1, ext.Name, ext.Path), false)
+			} else {
+				v.addValidation("Extensions", false,
+					fmt.Sprintf("Extension %d ('%s'): cannot access path '%s': %v", i+1, ext.Name, ext.Path, err), false)
+			}
+			pathErrorCount++
+			continue
+		}
+
+		// Check for extension.yaml manifest file if the extension is enabled
+		if ext.Enabled {
+			manifestPath := filepath.Join(extPath, "extension.yaml")
+			if _, err := v.fs.Stat(manifestPath); err != nil {
+				if os.IsNotExist(err) {
+					v.addValidation("Extensions", false,
+						fmt.Sprintf("Extension %d ('%s'): manifest file 'extension.yaml' not found", i+1, ext.Name), false)
+				} else {
+					v.addValidation("Extensions", false,
+						fmt.Sprintf("Extension %d ('%s'): cannot access manifest: %v", i+1, ext.Name, err), false)
+				}
+				manifestErrorCount++
+			}
+		}
+	}
+
+	enabledCount := 0
+	for _, ext := range v.cfg.Extensions {
+		if ext.Enabled {
+			enabledCount++
+		}
+	}
+
+	if pathErrorCount == 0 && manifestErrorCount == 0 {
+		v.addValidation("Extensions", true,
+			fmt.Sprintf("Configured with %d extension(s) (%d enabled)", len(v.cfg.Extensions), enabledCount), false)
+	}
+}
+
+// addValidation adds a validation result to the list.
+func (v *Validator) addValidation(category string, passed bool, message string, warning bool) {
+	v.validations = append(v.validations, ValidationResult{
+		Category: category,
+		Passed:   passed,
+		Message:  message,
+		Warning:  warning,
+	})
+}
+
+// HasErrors returns true if any validation failed.
+func HasErrors(results []ValidationResult) bool {
+	for _, r := range results {
+		if !r.Passed && !r.Warning {
+			return true
+		}
+	}
+	return false
+}
+
+// ErrorCount returns the number of failed validations.
+func ErrorCount(results []ValidationResult) int {
+	count := 0
+	for _, r := range results {
+		if !r.Passed && !r.Warning {
+			count++
+		}
+	}
+	return count
+}
+
+// WarningCount returns the number of warnings.
+func WarningCount(results []ValidationResult) int {
+	count := 0
+	for _, r := range results {
+		if r.Warning {
+			count++
+		}
+	}
+	return count
+}

--- a/internal/config/validator_test.go
+++ b/internal/config/validator_test.go
@@ -1,0 +1,1370 @@
+package config
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/indaco/sley/internal/core"
+)
+
+func TestValidator_ValidateYAMLSyntax(t *testing.T) {
+	tests := []struct {
+		name       string
+		configPath string
+		setupFS    func(*core.MockFileSystem)
+		wantPass   bool
+		wantMsg    string
+	}{
+		{
+			name:       "no config file",
+			configPath: "",
+			setupFS:    func(fs *core.MockFileSystem) {},
+			wantPass:   true,
+			wantMsg:    "No .sley.yaml file found, using defaults",
+		},
+		{
+			name:       "valid config file",
+			configPath: ".sley.yaml",
+			setupFS: func(fs *core.MockFileSystem) {
+				_ = fs.WriteFile(".sley.yaml", []byte("path: .version\n"), 0644)
+			},
+			wantPass: true,
+			wantMsg:  "Configuration file is valid YAML",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			fs := core.NewMockFileSystem()
+			tt.setupFS(fs)
+
+			cfg := &Config{Path: ".version"}
+			validator := NewValidator(fs, cfg, tt.configPath, ".")
+
+			results, err := validator.Validate()
+			if err != nil {
+				t.Fatalf("Validate() error = %v", err)
+			}
+
+			// Find YAML Syntax validation result
+			var found bool
+			for _, r := range results {
+				if r.Category == "YAML Syntax" {
+					found = true
+					if r.Passed != tt.wantPass {
+						t.Errorf("YAML Syntax validation passed = %v, want %v", r.Passed, tt.wantPass)
+					}
+					if r.Message != tt.wantMsg {
+						t.Errorf("YAML Syntax validation message = %q, want %q", r.Message, tt.wantMsg)
+					}
+				}
+			}
+
+			if !found {
+				t.Error("YAML Syntax validation result not found")
+			}
+		})
+	}
+}
+
+func TestValidator_ValidateTagManagerConfig(t *testing.T) {
+	tests := []struct {
+		name      string
+		config    *Config
+		wantPass  bool
+		wantError bool
+	}{
+		{
+			name: "valid tag manager config",
+			config: &Config{
+				Plugins: &PluginConfig{
+					TagManager: &TagManagerConfig{
+						Enabled: true,
+						Prefix:  "v",
+					},
+				},
+			},
+			wantPass:  true,
+			wantError: false,
+		},
+		{
+			name: "invalid prefix with whitespace",
+			config: &Config{
+				Plugins: &PluginConfig{
+					TagManager: &TagManagerConfig{
+						Enabled: true,
+						Prefix:  "v ",
+					},
+				},
+			},
+			wantPass:  false,
+			wantError: true,
+		},
+		{
+			name: "invalid prefix with slash",
+			config: &Config{
+				Plugins: &PluginConfig{
+					TagManager: &TagManagerConfig{
+						Enabled: true,
+						Prefix:  "v/",
+					},
+				},
+			},
+			wantPass:  false,
+			wantError: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			fs := core.NewMockFileSystem()
+			validator := NewValidator(fs, tt.config, "", ".")
+
+			results, err := validator.Validate()
+			if err != nil {
+				t.Fatalf("Validate() error = %v", err)
+			}
+
+			// Find tag-manager validation result
+			var found bool
+			for _, r := range results {
+				if r.Category == "Plugin: tag-manager" {
+					found = true
+					if tt.wantError && r.Passed {
+						t.Errorf("Expected tag-manager validation to fail, but it passed")
+					}
+					if !tt.wantError && !r.Passed {
+						t.Errorf("Expected tag-manager validation to pass, but it failed: %s", r.Message)
+					}
+				}
+			}
+
+			if tt.config.Plugins.TagManager != nil && tt.config.Plugins.TagManager.Enabled && !found {
+				t.Error("tag-manager validation result not found")
+			}
+		})
+	}
+}
+
+func TestValidator_ValidateVersionValidatorConfig(t *testing.T) {
+	tests := []struct {
+		name      string
+		config    *Config
+		wantError bool
+	}{
+		{
+			name: "valid rules",
+			config: &Config{
+				Plugins: &PluginConfig{
+					VersionValidator: &VersionValidatorConfig{
+						Enabled: true,
+						Rules: []ValidationRule{
+							{
+								Type:    "pre-release-format",
+								Pattern: `^(alpha|beta|rc)\.\d+$`,
+								Enabled: true,
+							},
+						},
+					},
+				},
+			},
+			wantError: false,
+		},
+		{
+			name: "invalid rule type",
+			config: &Config{
+				Plugins: &PluginConfig{
+					VersionValidator: &VersionValidatorConfig{
+						Enabled: true,
+						Rules: []ValidationRule{
+							{
+								Type:    "unknown-rule-type",
+								Enabled: true,
+							},
+						},
+					},
+				},
+			},
+			wantError: true,
+		},
+		{
+			name: "invalid regex pattern",
+			config: &Config{
+				Plugins: &PluginConfig{
+					VersionValidator: &VersionValidatorConfig{
+						Enabled: true,
+						Rules: []ValidationRule{
+							{
+								Type:    "pre-release-format",
+								Pattern: "[invalid(regex",
+								Enabled: true,
+							},
+						},
+					},
+				},
+			},
+			wantError: true,
+		},
+		{
+			name: "branch-constraint missing branch",
+			config: &Config{
+				Plugins: &PluginConfig{
+					VersionValidator: &VersionValidatorConfig{
+						Enabled: true,
+						Rules: []ValidationRule{
+							{
+								Type:    "branch-constraint",
+								Allowed: []string{"patch", "minor"},
+								Enabled: true,
+							},
+						},
+					},
+				},
+			},
+			wantError: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			fs := core.NewMockFileSystem()
+			validator := NewValidator(fs, tt.config, "", ".")
+
+			results, err := validator.Validate()
+			if err != nil {
+				t.Fatalf("Validate() error = %v", err)
+			}
+
+			hasError := false
+			for _, r := range results {
+				if r.Category == "Plugin: version-validator" && !r.Passed && !r.Warning {
+					hasError = true
+					break
+				}
+			}
+
+			if hasError != tt.wantError {
+				t.Errorf("version-validator validation error = %v, want %v", hasError, tt.wantError)
+			}
+		})
+	}
+}
+
+func TestValidator_ValidateDependencyCheckConfig(t *testing.T) {
+	tests := []struct {
+		name      string
+		config    *Config
+		setupFS   func(*core.MockFileSystem)
+		wantError bool
+	}{
+		{
+			name: "valid file exists",
+			config: &Config{
+				Plugins: &PluginConfig{
+					DependencyCheck: &DependencyCheckConfig{
+						Enabled: true,
+						Files: []DependencyFileConfig{
+							{
+								Path:   "package.json",
+								Format: "json",
+								Field:  "version",
+							},
+						},
+					},
+				},
+			},
+			setupFS: func(fs *core.MockFileSystem) {
+				_ = fs.WriteFile("package.json", []byte(`{"version": "1.0.0"}`), 0644)
+			},
+			wantError: false,
+		},
+		{
+			name: "file does not exist",
+			config: &Config{
+				Plugins: &PluginConfig{
+					DependencyCheck: &DependencyCheckConfig{
+						Enabled: true,
+						Files: []DependencyFileConfig{
+							{
+								Path:   "missing.json",
+								Format: "json",
+								Field:  "version",
+							},
+						},
+					},
+				},
+			},
+			setupFS:   func(fs *core.MockFileSystem) {},
+			wantError: true,
+		},
+		{
+			name: "invalid format",
+			config: &Config{
+				Plugins: &PluginConfig{
+					DependencyCheck: &DependencyCheckConfig{
+						Enabled: true,
+						Files: []DependencyFileConfig{
+							{
+								Path:   "file.txt",
+								Format: "unknown",
+								Field:  "version",
+							},
+						},
+					},
+				},
+			},
+			setupFS: func(fs *core.MockFileSystem) {
+				_ = fs.WriteFile("file.txt", []byte("content"), 0644)
+			},
+			wantError: true,
+		},
+		{
+			name: "regex format with invalid pattern",
+			config: &Config{
+				Plugins: &PluginConfig{
+					DependencyCheck: &DependencyCheckConfig{
+						Enabled: true,
+						Files: []DependencyFileConfig{
+							{
+								Path:    "file.txt",
+								Format:  "regex",
+								Pattern: "[invalid(regex",
+							},
+						},
+					},
+				},
+			},
+			setupFS: func(fs *core.MockFileSystem) {
+				_ = fs.WriteFile("file.txt", []byte("content"), 0644)
+			},
+			wantError: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			fs := core.NewMockFileSystem()
+			tt.setupFS(fs)
+
+			validator := NewValidator(fs, tt.config, "", ".")
+
+			results, err := validator.Validate()
+			if err != nil {
+				t.Fatalf("Validate() error = %v", err)
+			}
+
+			hasError := false
+			for _, r := range results {
+				if r.Category == "Plugin: dependency-check" && !r.Passed && !r.Warning {
+					hasError = true
+					break
+				}
+			}
+
+			if hasError != tt.wantError {
+				t.Errorf("dependency-check validation error = %v, want %v", hasError, tt.wantError)
+			}
+		})
+	}
+}
+
+func TestValidator_ValidateWorkspaceConfig(t *testing.T) {
+	tests := []struct {
+		name      string
+		config    *Config
+		setupFS   func(*core.MockFileSystem)
+		wantError bool
+	}{
+		{
+			name: "valid explicit modules",
+			config: &Config{
+				Workspace: &WorkspaceConfig{
+					Modules: []ModuleConfig{
+						{
+							Name: "module1",
+							Path: "module1/.version",
+						},
+						{
+							Name: "module2",
+							Path: "module2/.version",
+						},
+					},
+				},
+			},
+			setupFS: func(fs *core.MockFileSystem) {
+				_ = fs.WriteFile("module1/.version", []byte("1.0.0"), 0644)
+				_ = fs.WriteFile("module2/.version", []byte("2.0.0"), 0644)
+			},
+			wantError: false,
+		},
+		{
+			name: "module path does not exist",
+			config: &Config{
+				Workspace: &WorkspaceConfig{
+					Modules: []ModuleConfig{
+						{
+							Name: "missing",
+							Path: "missing/.version",
+						},
+					},
+				},
+			},
+			setupFS:   func(fs *core.MockFileSystem) {},
+			wantError: true,
+		},
+		{
+			name: "duplicate module names",
+			config: &Config{
+				Workspace: &WorkspaceConfig{
+					Modules: []ModuleConfig{
+						{
+							Name: "duplicate",
+							Path: "module1/.version",
+						},
+						{
+							Name: "duplicate",
+							Path: "module2/.version",
+						},
+					},
+				},
+			},
+			setupFS: func(fs *core.MockFileSystem) {
+				_ = fs.WriteFile("module1/.version", []byte("1.0.0"), 0644)
+				_ = fs.WriteFile("module2/.version", []byte("2.0.0"), 0644)
+			},
+			wantError: true,
+		},
+		{
+			name: "valid discovery config",
+			config: &Config{
+				Workspace: &WorkspaceConfig{
+					Discovery: &DiscoveryConfig{
+						Exclude: []string{"node_modules", "vendor"},
+					},
+				},
+			},
+			setupFS:   func(fs *core.MockFileSystem) {},
+			wantError: false,
+		},
+		{
+			name: "negative max depth",
+			config: &Config{
+				Workspace: &WorkspaceConfig{
+					Discovery: &DiscoveryConfig{
+						MaxDepth: func() *int { v := -1; return &v }(),
+					},
+				},
+			},
+			setupFS:   func(fs *core.MockFileSystem) {},
+			wantError: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			fs := core.NewMockFileSystem()
+			tt.setupFS(fs)
+
+			validator := NewValidator(fs, tt.config, "", ".")
+
+			results, err := validator.Validate()
+			if err != nil {
+				t.Fatalf("Validate() error = %v", err)
+			}
+
+			hasError := false
+			for _, r := range results {
+				if (r.Category == "Workspace: Modules" || r.Category == "Workspace: Discovery") &&
+					!r.Passed && !r.Warning {
+					hasError = true
+					break
+				}
+			}
+
+			if hasError != tt.wantError {
+				t.Errorf("workspace validation error = %v, want %v", hasError, tt.wantError)
+			}
+		})
+	}
+}
+
+func TestValidator_ValidateChangelogGeneratorConfig(t *testing.T) {
+	tests := []struct {
+		name      string
+		config    *Config
+		wantError bool
+	}{
+		{
+			name: "valid config",
+			config: &Config{
+				Plugins: &PluginConfig{
+					ChangelogGenerator: &ChangelogGeneratorConfig{
+						Enabled: true,
+						Mode:    "versioned",
+						Format:  "grouped",
+					},
+				},
+			},
+			wantError: false,
+		},
+		{
+			name: "invalid mode",
+			config: &Config{
+				Plugins: &PluginConfig{
+					ChangelogGenerator: &ChangelogGeneratorConfig{
+						Enabled: true,
+						Mode:    "invalid",
+					},
+				},
+			},
+			wantError: true,
+		},
+		{
+			name: "invalid format",
+			config: &Config{
+				Plugins: &PluginConfig{
+					ChangelogGenerator: &ChangelogGeneratorConfig{
+						Enabled: true,
+						Format:  "invalid",
+					},
+				},
+			},
+			wantError: true,
+		},
+		{
+			name: "invalid repository provider",
+			config: &Config{
+				Plugins: &PluginConfig{
+					ChangelogGenerator: &ChangelogGeneratorConfig{
+						Enabled: true,
+						Repository: &RepositoryConfig{
+							Provider: "invalid",
+						},
+					},
+				},
+			},
+			wantError: true,
+		},
+		{
+			name: "custom provider without host",
+			config: &Config{
+				Plugins: &PluginConfig{
+					ChangelogGenerator: &ChangelogGeneratorConfig{
+						Enabled: true,
+						Repository: &RepositoryConfig{
+							Provider: "custom",
+						},
+					},
+				},
+			},
+			wantError: true,
+		},
+		{
+			name: "invalid exclude pattern",
+			config: &Config{
+				Plugins: &PluginConfig{
+					ChangelogGenerator: &ChangelogGeneratorConfig{
+						Enabled:         true,
+						ExcludePatterns: []string{"[invalid(regex"},
+					},
+				},
+			},
+			wantError: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			fs := core.NewMockFileSystem()
+			validator := NewValidator(fs, tt.config, "", ".")
+
+			results, err := validator.Validate()
+			if err != nil {
+				t.Fatalf("Validate() error = %v", err)
+			}
+
+			hasError := false
+			for _, r := range results {
+				if r.Category == "Plugin: changelog-generator" && !r.Passed && !r.Warning {
+					hasError = true
+					break
+				}
+			}
+
+			if hasError != tt.wantError {
+				t.Errorf("changelog-generator validation error = %v, want %v", hasError, tt.wantError)
+			}
+		})
+	}
+}
+
+func TestValidator_ValidateAuditLogConfig(t *testing.T) {
+	tests := []struct {
+		name      string
+		config    *Config
+		wantError bool
+	}{
+		{
+			name: "valid json format",
+			config: &Config{
+				Plugins: &PluginConfig{
+					AuditLog: &AuditLogConfig{
+						Enabled: true,
+						Format:  "json",
+					},
+				},
+			},
+			wantError: false,
+		},
+		{
+			name: "valid yaml format",
+			config: &Config{
+				Plugins: &PluginConfig{
+					AuditLog: &AuditLogConfig{
+						Enabled: true,
+						Format:  "yaml",
+					},
+				},
+			},
+			wantError: false,
+		},
+		{
+			name: "invalid format",
+			config: &Config{
+				Plugins: &PluginConfig{
+					AuditLog: &AuditLogConfig{
+						Enabled: true,
+						Format:  "xml",
+					},
+				},
+			},
+			wantError: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			fs := core.NewMockFileSystem()
+			validator := NewValidator(fs, tt.config, "", ".")
+
+			results, err := validator.Validate()
+			if err != nil {
+				t.Fatalf("Validate() error = %v", err)
+			}
+
+			hasError := false
+			for _, r := range results {
+				if r.Category == "Plugin: audit-log" && !r.Passed && !r.Warning {
+					hasError = true
+					break
+				}
+			}
+
+			if hasError != tt.wantError {
+				t.Errorf("audit-log validation error = %v, want %v", hasError, tt.wantError)
+			}
+		})
+	}
+}
+
+func TestHasErrors(t *testing.T) {
+	tests := []struct {
+		name    string
+		results []ValidationResult
+		want    bool
+	}{
+		{
+			name:    "no results",
+			results: []ValidationResult{},
+			want:    false,
+		},
+		{
+			name: "all passed",
+			results: []ValidationResult{
+				{Passed: true, Warning: false},
+				{Passed: true, Warning: false},
+			},
+			want: false,
+		},
+		{
+			name: "has errors",
+			results: []ValidationResult{
+				{Passed: true, Warning: false},
+				{Passed: false, Warning: false},
+			},
+			want: true,
+		},
+		{
+			name: "only warnings",
+			results: []ValidationResult{
+				{Passed: true, Warning: false},
+				{Passed: true, Warning: true},
+			},
+			want: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := HasErrors(tt.results); got != tt.want {
+				t.Errorf("HasErrors() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestErrorCount(t *testing.T) {
+	tests := []struct {
+		name    string
+		results []ValidationResult
+		want    int
+	}{
+		{
+			name:    "no results",
+			results: []ValidationResult{},
+			want:    0,
+		},
+		{
+			name: "no errors",
+			results: []ValidationResult{
+				{Passed: true, Warning: false},
+				{Passed: true, Warning: true},
+			},
+			want: 0,
+		},
+		{
+			name: "has errors",
+			results: []ValidationResult{
+				{Passed: true, Warning: false},
+				{Passed: false, Warning: false},
+				{Passed: false, Warning: false},
+				{Passed: true, Warning: true},
+			},
+			want: 2,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := ErrorCount(tt.results); got != tt.want {
+				t.Errorf("ErrorCount() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestWarningCount(t *testing.T) {
+	tests := []struct {
+		name    string
+		results []ValidationResult
+		want    int
+	}{
+		{
+			name:    "no results",
+			results: []ValidationResult{},
+			want:    0,
+		},
+		{
+			name: "no warnings",
+			results: []ValidationResult{
+				{Passed: true, Warning: false},
+				{Passed: false, Warning: false},
+			},
+			want: 0,
+		},
+		{
+			name: "has warnings",
+			results: []ValidationResult{
+				{Passed: true, Warning: false},
+				{Passed: true, Warning: true},
+				{Passed: true, Warning: true},
+				{Passed: false, Warning: false},
+			},
+			want: 2,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := WarningCount(tt.results); got != tt.want {
+				t.Errorf("WarningCount() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestValidator_ValidateChangelogParserConfig(t *testing.T) {
+	tests := []struct {
+		name      string
+		config    *Config
+		setupFS   func(*core.MockFileSystem)
+		wantError bool
+	}{
+		{
+			name: "valid changelog file",
+			config: &Config{
+				Plugins: &PluginConfig{
+					ChangelogParser: &ChangelogParserConfig{
+						Enabled:  true,
+						Path:     "CHANGELOG.md",
+						Priority: "changelog",
+					},
+				},
+			},
+			setupFS: func(fs *core.MockFileSystem) {
+				_ = fs.WriteFile("CHANGELOG.md", []byte("# Changelog\n"), 0644)
+			},
+			wantError: false,
+		},
+		{
+			name: "changelog file does not exist",
+			config: &Config{
+				Plugins: &PluginConfig{
+					ChangelogParser: &ChangelogParserConfig{
+						Enabled: true,
+						Path:    "MISSING.md",
+					},
+				},
+			},
+			setupFS:   func(fs *core.MockFileSystem) {},
+			wantError: true,
+		},
+		{
+			name: "invalid priority value",
+			config: &Config{
+				Plugins: &PluginConfig{
+					ChangelogParser: &ChangelogParserConfig{
+						Enabled:  true,
+						Path:     "CHANGELOG.md",
+						Priority: "invalid-priority",
+					},
+				},
+			},
+			setupFS: func(fs *core.MockFileSystem) {
+				_ = fs.WriteFile("CHANGELOG.md", []byte("# Changelog\n"), 0644)
+			},
+			wantError: true,
+		},
+		{
+			name: "default changelog path",
+			config: &Config{
+				Plugins: &PluginConfig{
+					ChangelogParser: &ChangelogParserConfig{
+						Enabled: true,
+						Path:    "",
+					},
+				},
+			},
+			setupFS: func(fs *core.MockFileSystem) {
+				_ = fs.WriteFile("CHANGELOG.md", []byte("# Changelog\n"), 0644)
+			},
+			wantError: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			fs := core.NewMockFileSystem()
+			tt.setupFS(fs)
+
+			validator := NewValidator(fs, tt.config, "", ".")
+
+			results, err := validator.Validate()
+			if err != nil {
+				t.Fatalf("Validate() error = %v", err)
+			}
+
+			hasError := false
+			for _, r := range results {
+				if r.Category == "Plugin: changelog-parser" && !r.Passed && !r.Warning {
+					hasError = true
+					break
+				}
+			}
+
+			if hasError != tt.wantError {
+				t.Errorf("changelog-parser validation error = %v, want %v", hasError, tt.wantError)
+			}
+		})
+	}
+}
+
+func TestValidator_ValidateReleaseGateConfig(t *testing.T) {
+	tests := []struct {
+		name        string
+		config      *Config
+		wantWarning bool
+	}{
+		{
+			name: "no conflicting branches",
+			config: &Config{
+				Plugins: &PluginConfig{
+					ReleaseGate: &ReleaseGateConfig{
+						Enabled:         true,
+						AllowedBranches: []string{"main", "develop"},
+					},
+				},
+			},
+			wantWarning: false,
+		},
+		{
+			name: "conflicting allowed and blocked branches",
+			config: &Config{
+				Plugins: &PluginConfig{
+					ReleaseGate: &ReleaseGateConfig{
+						Enabled:         true,
+						AllowedBranches: []string{"main"},
+						BlockedBranches: []string{"develop"},
+					},
+				},
+			},
+			wantWarning: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			fs := core.NewMockFileSystem()
+			validator := NewValidator(fs, tt.config, "", ".")
+
+			results, err := validator.Validate()
+			if err != nil {
+				t.Fatalf("Validate() error = %v", err)
+			}
+
+			hasWarning := false
+			for _, r := range results {
+				if r.Category == "Plugin: release-gate" && r.Warning {
+					hasWarning = true
+					break
+				}
+			}
+
+			if hasWarning != tt.wantWarning {
+				t.Errorf("release-gate validation warning = %v, want %v", hasWarning, tt.wantWarning)
+			}
+		})
+	}
+}
+
+func TestValidator_ValidateExtensionConfigs(t *testing.T) {
+	tests := []struct {
+		name      string
+		config    *Config
+		setupFS   func(*core.MockFileSystem)
+		wantError bool
+	}{
+		{
+			name: "valid extension with manifest",
+			config: &Config{
+				Extensions: []ExtensionConfig{
+					{
+						Name:    "test-extension",
+						Path:    "extensions/test",
+						Enabled: true,
+					},
+				},
+			},
+			setupFS: func(fs *core.MockFileSystem) {
+				// Create the directory explicitly
+				_ = fs.MkdirAll("extensions/test", 0755)
+				_ = fs.WriteFile("extensions/test/extension.yaml", []byte("name: test"), 0644)
+			},
+			wantError: false,
+		},
+		{
+			name: "extension path does not exist",
+			config: &Config{
+				Extensions: []ExtensionConfig{
+					{
+						Name:    "missing-extension",
+						Path:    "extensions/missing",
+						Enabled: false,
+					},
+				},
+			},
+			setupFS:   func(fs *core.MockFileSystem) {},
+			wantError: true,
+		},
+		{
+			name: "enabled extension missing manifest",
+			config: &Config{
+				Extensions: []ExtensionConfig{
+					{
+						Name:    "no-manifest",
+						Path:    "extensions/no-manifest",
+						Enabled: true,
+					},
+				},
+			},
+			setupFS: func(fs *core.MockFileSystem) {
+				// Create directory with a file but no manifest
+				_ = fs.MkdirAll("extensions/no-manifest", 0755)
+				_ = fs.WriteFile("extensions/no-manifest/script.sh", []byte("#!/bin/bash"), 0755)
+			},
+			wantError: true,
+		},
+		{
+			name: "disabled extension missing manifest - should not error",
+			config: &Config{
+				Extensions: []ExtensionConfig{
+					{
+						Name:    "disabled-ext",
+						Path:    "extensions/disabled",
+						Enabled: false,
+					},
+				},
+			},
+			setupFS: func(fs *core.MockFileSystem) {
+				// Create directory with a file
+				_ = fs.MkdirAll("extensions/disabled", 0755)
+				_ = fs.WriteFile("extensions/disabled/script.sh", []byte("#!/bin/bash"), 0755)
+			},
+			wantError: false,
+		},
+		{
+			name: "multiple extensions mixed states",
+			config: &Config{
+				Extensions: []ExtensionConfig{
+					{
+						Name:    "valid-ext",
+						Path:    "extensions/valid",
+						Enabled: true,
+					},
+					{
+						Name:    "disabled-ext",
+						Path:    "extensions/disabled",
+						Enabled: false,
+					},
+				},
+			},
+			setupFS: func(fs *core.MockFileSystem) {
+				_ = fs.MkdirAll("extensions/valid", 0755)
+				_ = fs.WriteFile("extensions/valid/extension.yaml", []byte("name: valid"), 0644)
+				_ = fs.MkdirAll("extensions/disabled", 0755)
+				_ = fs.WriteFile("extensions/disabled/script.sh", []byte("#!/bin/bash"), 0755)
+			},
+			wantError: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			fs := core.NewMockFileSystem()
+			tt.setupFS(fs)
+
+			validator := NewValidator(fs, tt.config, "", ".")
+
+			results, err := validator.Validate()
+			if err != nil {
+				t.Fatalf("Validate() error = %v", err)
+			}
+
+			hasError := false
+			for _, r := range results {
+				if r.Category == "Extensions" && !r.Passed && !r.Warning {
+					hasError = true
+					break
+				}
+			}
+
+			if hasError != tt.wantError {
+				t.Errorf("extension validation error = %v, want %v", hasError, tt.wantError)
+			}
+		})
+	}
+}
+
+func TestValidator_ValidateCommitParserPlugin(t *testing.T) {
+	tests := []struct {
+		name   string
+		config *Config
+	}{
+		{
+			name: "commit parser enabled",
+			config: &Config{
+				Plugins: &PluginConfig{
+					CommitParser: true,
+				},
+			},
+		},
+		{
+			name: "commit parser disabled",
+			config: &Config{
+				Plugins: &PluginConfig{
+					CommitParser: false,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			fs := core.NewMockFileSystem()
+			validator := NewValidator(fs, tt.config, "", ".")
+
+			_, err := validator.Validate()
+			if err != nil {
+				t.Fatalf("Validate() error = %v", err)
+			}
+			// Commit parser doesn't have specific validation, this just ensures it doesn't break
+		})
+	}
+}
+
+func TestValidator_ValidateVersionValidatorBranchConstraint(t *testing.T) {
+	tests := []struct {
+		name      string
+		config    *Config
+		wantError bool
+	}{
+		{
+			name: "valid branch constraint",
+			config: &Config{
+				Plugins: &PluginConfig{
+					VersionValidator: &VersionValidatorConfig{
+						Enabled: true,
+						Rules: []ValidationRule{
+							{
+								Type:    "branch-constraint",
+								Branch:  "main",
+								Allowed: []string{"major", "minor"},
+								Enabled: true,
+							},
+						},
+					},
+				},
+			},
+			wantError: false,
+		},
+		{
+			name: "branch constraint missing allowed",
+			config: &Config{
+				Plugins: &PluginConfig{
+					VersionValidator: &VersionValidatorConfig{
+						Enabled: true,
+						Rules: []ValidationRule{
+							{
+								Type:    "branch-constraint",
+								Branch:  "main",
+								Enabled: true,
+							},
+						},
+					},
+				},
+			},
+			wantError: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			fs := core.NewMockFileSystem()
+			validator := NewValidator(fs, tt.config, "", ".")
+
+			results, err := validator.Validate()
+			if err != nil {
+				t.Fatalf("Validate() error = %v", err)
+			}
+
+			hasError := false
+			for _, r := range results {
+				if r.Category == "Plugin: version-validator" && !r.Passed && !r.Warning {
+					hasError = true
+					break
+				}
+			}
+
+			if hasError != tt.wantError {
+				t.Errorf("version-validator validation error = %v, want %v", hasError, tt.wantError)
+			}
+		})
+	}
+}
+
+func TestValidator_ValidateNoPlugins(t *testing.T) {
+	tests := []struct {
+		name   string
+		config *Config
+	}{
+		{
+			name: "no plugin config",
+			config: &Config{
+				Plugins: nil,
+			},
+		},
+		{
+			name:   "nil config",
+			config: &Config{},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			fs := core.NewMockFileSystem()
+			validator := NewValidator(fs, tt.config, "", ".")
+
+			results, err := validator.Validate()
+			if err != nil {
+				t.Fatalf("Validate() error = %v", err)
+			}
+
+			// Should have YAML syntax validation at minimum
+			if len(results) == 0 {
+				t.Error("expected at least YAML syntax validation result")
+			}
+
+			// Find plugin configuration validation
+			for _, r := range results {
+				if r.Category == "Plugin Configuration" {
+					if !r.Passed {
+						t.Errorf("expected plugin configuration to pass with no config")
+					}
+				}
+			}
+		})
+	}
+}
+
+func TestValidator_ValidateVersionValidatorNoRules(t *testing.T) {
+	config := &Config{
+		Plugins: &PluginConfig{
+			VersionValidator: &VersionValidatorConfig{
+				Enabled: true,
+				Rules:   []ValidationRule{},
+			},
+		},
+	}
+
+	fs := core.NewMockFileSystem()
+	validator := NewValidator(fs, config, "", ".")
+
+	results, err := validator.Validate()
+	if err != nil {
+		t.Fatalf("Validate() error = %v", err)
+	}
+
+	// Should have a warning about no rules
+	hasWarning := false
+	for _, r := range results {
+		if r.Category == "Plugin: version-validator" && r.Warning {
+			hasWarning = true
+			break
+		}
+	}
+
+	if !hasWarning {
+		t.Error("expected warning for version-validator with no rules")
+	}
+}
+
+func TestValidator_ValidateDependencyCheckNoFiles(t *testing.T) {
+	config := &Config{
+		Plugins: &PluginConfig{
+			DependencyCheck: &DependencyCheckConfig{
+				Enabled: true,
+				Files:   []DependencyFileConfig{},
+			},
+		},
+	}
+
+	fs := core.NewMockFileSystem()
+	validator := NewValidator(fs, config, "", ".")
+
+	results, err := validator.Validate()
+	if err != nil {
+		t.Fatalf("Validate() error = %v", err)
+	}
+
+	// Should have a warning about no files
+	hasWarning := false
+	for _, r := range results {
+		if r.Category == "Plugin: dependency-check" && r.Warning {
+			hasWarning = true
+			break
+		}
+	}
+
+	if !hasWarning {
+		t.Error("expected warning for dependency-check with no files")
+	}
+}
+
+func TestValidator_ValidateWorkspaceOverbreadExcludePattern(t *testing.T) {
+	config := &Config{
+		Workspace: &WorkspaceConfig{
+			Discovery: &DiscoveryConfig{
+				Exclude: []string{"**/**/**"},
+			},
+		},
+	}
+
+	fs := core.NewMockFileSystem()
+	validator := NewValidator(fs, config, "", ".")
+
+	results, err := validator.Validate()
+	if err != nil {
+		t.Fatalf("Validate() error = %v", err)
+	}
+
+	// Should have a warning about overly broad pattern
+	hasWarning := false
+	for _, r := range results {
+		if r.Category == "Workspace: Discovery" && r.Warning && strings.Contains(r.Message, "overly broad") {
+			hasWarning = true
+			break
+		}
+	}
+
+	if !hasWarning {
+		t.Error("expected warning for overly broad exclude pattern")
+	}
+}
+
+func TestValidator_ValidateChangelogGeneratorCustomProvider(t *testing.T) {
+	tests := []struct {
+		name      string
+		config    *Config
+		wantError bool
+	}{
+		{
+			name: "custom provider with host",
+			config: &Config{
+				Plugins: &PluginConfig{
+					ChangelogGenerator: &ChangelogGeneratorConfig{
+						Enabled: true,
+						Repository: &RepositoryConfig{
+							Provider: "custom",
+							Host:     "git.example.com",
+						},
+					},
+				},
+			},
+			wantError: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			fs := core.NewMockFileSystem()
+			validator := NewValidator(fs, tt.config, "", ".")
+
+			results, err := validator.Validate()
+			if err != nil {
+				t.Fatalf("Validate() error = %v", err)
+			}
+
+			hasError := false
+			for _, r := range results {
+				if r.Category == "Plugin: changelog-generator" && !r.Passed && !r.Warning {
+					hasError = true
+					break
+				}
+			}
+
+			if hasError != tt.wantError {
+				t.Errorf("changelog-generator validation error = %v, want %v", hasError, tt.wantError)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

- Add ConfigValidator for comprehensive .sley.yaml validation
- Validate plugin configs (tag-manager, version-validator, etc.)
- Validate workspace discovery and module configurations
- Validate extension paths and manifests
- Display results with styled output (colored badges, categories)