### PR TITLE
feat(pre): add multi-module workspace support

### DIFF
--- a/cmd/sley/cli.go
+++ b/cmd/sley/cli.go
@@ -58,7 +58,7 @@ func newCLI(cfg *config.Config) *cli.Command {
 			setcmd.Run(cfg),
 			bumpcmd.Run(cfg),
 			changelogcmd.Run(cfg),
-			precmd.Run(),
+			precmd.Run(cfg),
 			doctorcmd.Run(cfg),
 			initcmd.Run(),
 			extensioncmd.Run(),

--- a/cmd/sley/initcmd/initcmd_test.go
+++ b/cmd/sley/initcmd/initcmd_test.go
@@ -164,7 +164,7 @@ func TestCLI_Command_InitializeVersionFilePermissionErrors(t *testing.T) {
 			cfg := &config.Config{Path: protectedPath}
 			appCli := testutils.BuildCLIForTests(
 				cfg.Path,
-				[]*cli.Command{Run(), bumpcmd.Run(cfg), precmd.Run()},
+				[]*cli.Command{Run(), bumpcmd.Run(cfg), precmd.Run(cfg)},
 			)
 
 			err := appCli.Run(context.Background(), append(tt.command, "--path", protectedPath))

--- a/cmd/sley/precmd/precmd.go
+++ b/cmd/sley/precmd/precmd.go
@@ -2,50 +2,86 @@ package precmd
 
 import (
 	"context"
+	"errors"
 	"fmt"
+	"os"
 
+	"github.com/indaco/sley/cmd/sley/flags"
 	"github.com/indaco/sley/internal/clix"
+	"github.com/indaco/sley/internal/config"
+	"github.com/indaco/sley/internal/core"
+	"github.com/indaco/sley/internal/operations"
+	"github.com/indaco/sley/internal/printer"
 	"github.com/indaco/sley/internal/semver"
+	"github.com/indaco/sley/internal/workspace"
 	"github.com/urfave/cli/v3"
 )
 
 // Run returns the "pre" command.
-func Run() *cli.Command {
+func Run(cfg *config.Config) *cli.Command {
+	cmdFlags := []cli.Flag{
+		&cli.StringFlag{
+			Name:     "label",
+			Usage:    "Pre-release label to set",
+			Required: true,
+		},
+		&cli.BoolFlag{
+			Name:  "inc",
+			Usage: "Increment numeric suffix if it exists or add '.1'",
+		},
+	}
+	cmdFlags = append(cmdFlags, flags.MultiModuleFlags()...)
+
 	return &cli.Command{
 		Name:      "pre",
 		Usage:     "Set pre-release label (e.g., alpha, beta.1)",
-		UsageText: "sley pre --label <label> [--inc]",
-		Flags: []cli.Flag{
-			&cli.StringFlag{
-				Name:     "label",
-				Usage:    "Pre-release label to set",
-				Required: true,
-			},
-			&cli.BoolFlag{
-				Name:  "inc",
-				Usage: "Increment numeric suffix if it exists or add '.1'",
-			},
-		},
+		UsageText: "sley pre --label <label> [--inc] [--all] [--module name]",
+		Flags:     cmdFlags,
 		Action: func(ctx context.Context, cmd *cli.Command) error {
-			return runPreCmd(cmd)
+			return runPreCmd(ctx, cmd, cfg)
 		},
 	}
 }
 
 // runPreCmd sets or increments the pre-release label.
-func runPreCmd(cmd *cli.Command) error {
-	path := cmd.String("path")
+func runPreCmd(ctx context.Context, cmd *cli.Command, cfg *config.Config) error {
 	label := cmd.String("label")
 	isInc := cmd.Bool("inc")
 
-	if _, err := clix.FromCommandFn(cmd); err != nil {
+	// Get execution context to determine single vs multi-module mode
+	execCtx, err := clix.GetExecutionContext(ctx, cmd, cfg)
+	if err != nil {
 		return err
 	}
 
+	// Handle single-module mode
+	if execCtx.IsSingleModule() {
+		return runSingleModulePre(execCtx.Path, label, isInc)
+	}
+
+	// Handle multi-module mode
+	return runMultiModulePre(ctx, cmd, execCtx, label, isInc)
+}
+
+// runSingleModulePre handles the single-module pre-release operation.
+func runSingleModulePre(path, label string, isInc bool) error {
+	// Auto-initialize if file doesn't exist
+	var version semver.SemVersion
 	version, err := semver.ReadVersion(path)
 	if err != nil {
-		return fmt.Errorf("failed to read version: %w", err)
+		if errors.Is(err, os.ErrNotExist) {
+			// Auto-initialize with default version
+			version = semver.SemVersion{Major: 0, Minor: 1, Patch: 0}
+			if err := semver.SaveVersion(path, version); err != nil {
+				return fmt.Errorf("failed to initialize version file: %w", err)
+			}
+			printer.PrintSuccess(fmt.Sprintf("Auto-initialized %s with default version", path))
+		} else {
+			return fmt.Errorf("failed to read version: %w", err)
+		}
 	}
+
+	oldVersion := version.String()
 
 	if isInc {
 		version.PreRelease = semver.IncrementPreRelease(version.PreRelease, label)
@@ -60,5 +96,70 @@ func runPreCmd(cmd *cli.Command) error {
 		return fmt.Errorf("failed to save version: %w", err)
 	}
 
+	printer.PrintSuccess(fmt.Sprintf("Updated version from %s to %s", oldVersion, version.String()))
 	return nil
+}
+
+// runMultiModulePre handles the multi-module pre-release operation.
+func runMultiModulePre(ctx context.Context, cmd *cli.Command, execCtx *clix.ExecutionContext, label string, isInc bool) error {
+	fs := core.NewOSFileSystem()
+	operation := operations.NewPreOperation(fs, label, isInc)
+
+	// Create executor with options from flags
+	parallel := cmd.Bool("parallel")
+	failFast := cmd.Bool("fail-fast") && !cmd.Bool("continue-on-error")
+
+	executor := workspace.NewExecutor(
+		workspace.WithParallel(parallel),
+		workspace.WithFailFast(failFast),
+	)
+
+	// Execute the operation on all modules
+	results, err := executor.Run(ctx, execCtx.Modules, operation)
+	if err != nil && failFast {
+		// In fail-fast mode, we may have partial results
+		// Fall through to display what we have
+		_ = err
+	}
+
+	// Format and display results
+	format := cmd.String("format")
+	quiet := cmd.Bool("quiet")
+
+	actionVerb := "updated"
+	if isInc {
+		actionVerb = "incremented"
+	}
+
+	operationName := fmt.Sprintf("Set pre-release to %s", label)
+	if isInc {
+		operationName = fmt.Sprintf("Increment pre-release with %s", label)
+	}
+
+	formatter := workspace.GetFormatterWithVerb(format, operationName, actionVerb)
+
+	if quiet {
+		// In quiet mode, just show summary
+		printQuietSummary(results)
+	} else {
+		fmt.Println(formatter.FormatResults(results))
+	}
+
+	// Return error if any failures occurred
+	if workspace.HasErrors(results) {
+		return fmt.Errorf("%d module(s) failed", workspace.ErrorCount(results))
+	}
+
+	return nil
+}
+
+// printQuietSummary prints a minimal summary of results.
+func printQuietSummary(results []workspace.ExecutionResult) {
+	success := workspace.SuccessCount(results)
+	errors := workspace.ErrorCount(results)
+	if errors > 0 {
+		printer.PrintWarning(fmt.Sprintf("Completed: %d succeeded, %d failed", success, errors))
+	} else {
+		printer.PrintSuccess(fmt.Sprintf("Success: %d module(s) updated", success))
+	}
 }

--- a/cmd/sley/precmd/precmd_test.go
+++ b/cmd/sley/precmd/precmd_test.go
@@ -9,10 +9,10 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/indaco/sley/internal/clix"
 	"github.com/indaco/sley/internal/config"
 	"github.com/indaco/sley/internal/semver"
 	"github.com/indaco/sley/internal/testutils"
+	"github.com/indaco/sley/internal/workspace"
 	"github.com/urfave/cli/v3"
 )
 
@@ -22,7 +22,7 @@ func TestCLI_PreCommand_StaticLabel(t *testing.T) {
 
 	// Prepare and run the CLI command
 	cfg := &config.Config{Path: versionPath}
-	appCli := testutils.BuildCLIForTests(cfg.Path, []*cli.Command{Run()})
+	appCli := testutils.BuildCLIForTests(cfg.Path, []*cli.Command{Run(cfg)})
 
 	testutils.WriteTempVersionFile(t, tmpDir, "1.2.3")
 	testutils.RunCLITest(t, appCli, []string{"sley", "pre", "--label", "beta.1"}, tmpDir)
@@ -39,7 +39,7 @@ func TestCLI_PreCommand_Increment(t *testing.T) {
 
 	// Prepare and run the CLI command
 	cfg := &config.Config{Path: versionPath}
-	appCli := testutils.BuildCLIForTests(cfg.Path, []*cli.Command{Run()})
+	appCli := testutils.BuildCLIForTests(cfg.Path, []*cli.Command{Run(cfg)})
 
 	testutils.RunCLITest(t, appCli, []string{"sley", "pre", "--label", "beta", "--inc"}, tmpDir)
 	content := testutils.ReadTempVersionFile(t, tmpDir)
@@ -54,7 +54,7 @@ func TestCLI_PreCommand_AutoInitFeedback(t *testing.T) {
 
 	// Prepare and run the CLI command
 	cfg := &config.Config{Path: versionPath}
-	appCli := testutils.BuildCLIForTests(cfg.Path, []*cli.Command{Run()})
+	appCli := testutils.BuildCLIForTests(cfg.Path, []*cli.Command{Run(cfg)})
 
 	output, err := testutils.CaptureStdout(func() {
 		testutils.RunCLITest(t, appCli, []string{"sley", "pre", "--label", "alpha"}, tmpDir)
@@ -80,7 +80,7 @@ func TestCLI_PreCommand_InvalidVersion(t *testing.T) {
 
 	// Prepare and run the CLI command
 	cfg := &config.Config{Path: defaultPath}
-	appCli := testutils.BuildCLIForTests(cfg.Path, []*cli.Command{Run()})
+	appCli := testutils.BuildCLIForTests(cfg.Path, []*cli.Command{Run(cfg)})
 
 	err := appCli.Run(context.Background(), []string{
 		"sley", "pre", "--label", "alpha", "--path", customPath,
@@ -110,7 +110,7 @@ func TestCLI_PreCommand_SaveVersionFails(t *testing.T) {
 
 		// Prepare and run the CLI command
 		cfg := &config.Config{Path: versionPath}
-		appCli := testutils.BuildCLIForTests(cfg.Path, []*cli.Command{Run()})
+		appCli := testutils.BuildCLIForTests(cfg.Path, []*cli.Command{Run(cfg)})
 
 		err := appCli.Run(context.Background(), []string{
 			"sley", "pre", "--label", "rc", "--path", versionPath,
@@ -138,22 +138,588 @@ func TestCLI_PreCommand_SaveVersionFails(t *testing.T) {
 	}
 }
 
-func TestCLI_PreCommand_FromCommandFails(t *testing.T) {
+// TestCLI_PreCommand_FromCommandFails is obsolete - the pre command now uses
+// GetExecutionContext instead of FromCommandFn, and auto-initializes missing files.
+// Keeping this as a placeholder for potential future execution context error testing.
+
+/* ------------------------------------------------------------------------- */
+/* SINGLE-MODULE OPERATIONS - ADDITIONAL TESTS                              */
+/* ------------------------------------------------------------------------- */
+
+func TestCLI_PreCommand_StaticLabel_Variants(t *testing.T) {
 	tmpDir := t.TempDir()
 	versionPath := filepath.Join(tmpDir, ".version")
 
-	// Backup and override clix.FromCommand
-	originalFromCommand := clix.FromCommandFn
-	clix.FromCommandFn = func(cmd *cli.Command) (bool, error) {
-		return false, fmt.Errorf("mock FromCommand error")
+	cfg := &config.Config{Path: versionPath}
+	appCli := testutils.BuildCLIForTests(cfg.Path, []*cli.Command{Run(cfg)})
+
+	tests := []struct {
+		name     string
+		initial  string
+		label    string
+		expected string
+	}{
+		{"set alpha", "1.2.3", "alpha", "1.2.4-alpha"},
+		{"set beta.1", "1.2.3", "beta.1", "1.2.4-beta.1"},
+		{"set rc.1", "2.0.0", "rc.1", "2.0.1-rc.1"},
+		{"replace existing pre-release", "1.2.3-alpha.1", "beta.1", "1.2.3-beta.1"},
+		{"replace with same label increments patch", "1.0.0-rc.1", "rc.2", "1.0.0-rc.2"},
 	}
-	t.Cleanup(func() { clix.FromCommandFn = originalFromCommand })
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			testutils.WriteTempVersionFile(t, tmpDir, tt.initial)
+			testutils.RunCLITest(t, appCli, []string{"sley", "pre", "--label", tt.label}, tmpDir)
+			content := testutils.ReadTempVersionFile(t, tmpDir)
+			if content != tt.expected {
+				t.Errorf("expected %q, got %q", tt.expected, content)
+			}
+		})
+	}
+}
+
+func TestCLI_PreCommand_Increment_Variants(t *testing.T) {
+	tmpDir := t.TempDir()
+	versionPath := filepath.Join(tmpDir, ".version")
 
 	cfg := &config.Config{Path: versionPath}
-	appCli := testutils.BuildCLIForTests(cfg.Path, []*cli.Command{Run()})
+	appCli := testutils.BuildCLIForTests(cfg.Path, []*cli.Command{Run(cfg)})
 
-	err := appCli.Run(context.Background(), []string{"sley", "pre", "--label", "beta.1"})
-	if err == nil || !strings.Contains(err.Error(), "mock FromCommand error") {
-		t.Fatalf("expected FromCommand error, got: %v", err)
+	tests := []struct {
+		name     string
+		initial  string
+		label    string
+		expected string
+	}{
+		{"increment beta.1 to beta.2", "1.2.3-beta.1", "beta", "1.2.3-beta.2"},
+		{"increment rc.5 to rc.6", "2.0.0-rc.5", "rc", "2.0.0-rc.6"},
+		{"increment alpha to alpha.1", "1.0.0-alpha", "alpha", "1.0.0-alpha.1"},
+		{"start increment on final version", "1.2.3", "beta", "1.2.3-beta.1"},
+		{"increment with no separator rc1 to rc2", "1.2.3-rc1", "rc", "1.2.3-rc2"},
+		{"increment with dash separator rc-1 to rc-2", "1.2.3-rc-1", "rc", "1.2.3-rc-2"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			testutils.WriteTempVersionFile(t, tmpDir, tt.initial)
+			testutils.RunCLITest(t, appCli, []string{"sley", "pre", "--label", tt.label, "--inc"}, tmpDir)
+			content := testutils.ReadTempVersionFile(t, tmpDir)
+			if content != tt.expected {
+				t.Errorf("expected %q, got %q", tt.expected, content)
+			}
+		})
+	}
+}
+
+func TestCLI_PreCommand_LabelSwitchWithIncrement(t *testing.T) {
+	tmpDir := t.TempDir()
+	versionPath := filepath.Join(tmpDir, ".version")
+
+	cfg := &config.Config{Path: versionPath}
+	appCli := testutils.BuildCLIForTests(cfg.Path, []*cli.Command{Run(cfg)})
+
+	tests := []struct {
+		name     string
+		initial  string
+		label    string
+		expected string
+	}{
+		{"switch from alpha to beta with inc", "1.2.3-alpha.5", "beta", "1.2.3-beta.1"},
+		{"switch from rc to beta with inc", "1.2.3-rc.2", "beta", "1.2.3-beta.1"},
+		{"same label increments", "1.2.3-beta.1", "beta", "1.2.3-beta.2"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			testutils.WriteTempVersionFile(t, tmpDir, tt.initial)
+			testutils.RunCLITest(t, appCli, []string{"sley", "pre", "--label", tt.label, "--inc"}, tmpDir)
+			content := testutils.ReadTempVersionFile(t, tmpDir)
+			if content != tt.expected {
+				t.Errorf("expected %q, got %q", tt.expected, content)
+			}
+		})
+	}
+}
+
+func TestCLI_PreCommand_EdgeCases(t *testing.T) {
+	tmpDir := t.TempDir()
+	versionPath := filepath.Join(tmpDir, ".version")
+
+	cfg := &config.Config{Path: versionPath}
+	appCli := testutils.BuildCLIForTests(cfg.Path, []*cli.Command{Run(cfg)})
+
+	tests := []struct {
+		name     string
+		initial  string
+		args     []string
+		expected string
+	}{
+		{
+			name:     "complex label",
+			initial:  "1.2.3",
+			args:     []string{"sley", "pre", "--label", "alpha.beta.1"},
+			expected: "1.2.4-alpha.beta.1",
+		},
+		{
+			name:     "numeric only label",
+			initial:  "1.2.3",
+			args:     []string{"sley", "pre", "--label", "123"},
+			expected: "1.2.4-123",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			testutils.WriteTempVersionFile(t, tmpDir, tt.initial)
+			testutils.RunCLITest(t, appCli, tt.args, tmpDir)
+			content := testutils.ReadTempVersionFile(t, tmpDir)
+			if content != tt.expected {
+				t.Errorf("expected %q, got %q", tt.expected, content)
+			}
+		})
+	}
+}
+
+func TestCLI_PreCommand_PermissionErrors(t *testing.T) {
+	if testutils.IsWindows() {
+		t.Skip("Skipping permission test on Windows")
+	}
+
+	tmp := t.TempDir()
+	protectedDir := filepath.Join(tmp, "protected")
+	if err := os.Mkdir(protectedDir, 0555); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.Chmod(protectedDir, 0755) })
+
+	versionPath := filepath.Join(protectedDir, ".version")
+
+	cfg := &config.Config{Path: versionPath}
+	appCli := testutils.BuildCLIForTests(cfg.Path, []*cli.Command{Run(cfg)})
+
+	err := appCli.Run(context.Background(), []string{
+		"sley", "pre", "--label", "alpha", "--path", versionPath,
+	})
+
+	if err == nil || !strings.Contains(err.Error(), "permission denied") {
+		t.Errorf("expected permission denied error, got: %v", err)
+	}
+}
+
+/* ------------------------------------------------------------------------- */
+/* MULTI-MODULE OPERATIONS TESTS                                            */
+/* ------------------------------------------------------------------------- */
+
+func TestCLI_PreCommand_MultiModule_All(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	// Create multi-module workspace
+	moduleA := filepath.Join(tmpDir, "module-a")
+	moduleB := filepath.Join(tmpDir, "module-b")
+	if err := os.MkdirAll(moduleA, 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(moduleB, 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	testutils.WriteTempVersionFile(t, moduleA, "1.0.0")
+	testutils.WriteTempVersionFile(t, moduleB, "2.0.0-alpha.1")
+
+	// Create config with workspace discovery enabled
+	enabled := true
+	recursive := true
+	maxDepth := 10
+	cfg := &config.Config{
+		Path: ".version",
+		Workspace: &config.WorkspaceConfig{
+			Discovery: &config.DiscoveryConfig{
+				Enabled:   &enabled,
+				Recursive: &recursive,
+				MaxDepth:  &maxDepth,
+			},
+		},
+	}
+
+	appCli := testutils.BuildCLIForTests(cfg.Path, []*cli.Command{Run(cfg)})
+
+	// Test with --all flag
+	output, err := testutils.CaptureStdout(func() {
+		testutils.RunCLITest(t, appCli, []string{"sley", "pre", "--label", "beta", "--all"}, tmpDir)
+	})
+	if err != nil {
+		t.Fatalf("Failed to capture stdout: %v", err)
+	}
+
+	// Verify both modules were updated
+	gotA := testutils.ReadTempVersionFile(t, moduleA)
+	gotB := testutils.ReadTempVersionFile(t, moduleB)
+
+	// Module A should have patch incremented then beta set
+	if gotA != "1.0.1-beta" {
+		t.Errorf("module-a version = %q, want %q", gotA, "1.0.1-beta")
+	}
+	// Module B should have existing pre-release replaced
+	if gotB != "2.0.0-beta" {
+		t.Errorf("module-b version = %q, want %q", gotB, "2.0.0-beta")
+	}
+
+	// Verify output contains operation name
+	if !strings.Contains(output, "Set pre-release to beta") {
+		t.Errorf("expected operation name in output, got: %q", output)
+	}
+}
+
+func TestCLI_PreCommand_MultiModule_Increment(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	// Create multi-module workspace
+	moduleA := filepath.Join(tmpDir, "module-a")
+	moduleB := filepath.Join(tmpDir, "module-b")
+	if err := os.MkdirAll(moduleA, 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(moduleB, 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	testutils.WriteTempVersionFile(t, moduleA, "1.0.0-rc.1")
+	testutils.WriteTempVersionFile(t, moduleB, "2.0.0-rc.5")
+
+	// Create config with workspace discovery enabled
+	enabled := true
+	recursive := true
+	maxDepth := 10
+	cfg := &config.Config{
+		Path: ".version",
+		Workspace: &config.WorkspaceConfig{
+			Discovery: &config.DiscoveryConfig{
+				Enabled:   &enabled,
+				Recursive: &recursive,
+				MaxDepth:  &maxDepth,
+			},
+		},
+	}
+
+	appCli := testutils.BuildCLIForTests(cfg.Path, []*cli.Command{Run(cfg)})
+
+	// Test with --all and --inc flags
+	output, err := testutils.CaptureStdout(func() {
+		testutils.RunCLITest(t, appCli, []string{"sley", "pre", "--label", "rc", "--inc", "--all"}, tmpDir)
+	})
+	if err != nil {
+		t.Fatalf("Failed to capture stdout: %v", err)
+	}
+
+	// Verify both modules were incremented
+	gotA := testutils.ReadTempVersionFile(t, moduleA)
+	gotB := testutils.ReadTempVersionFile(t, moduleB)
+
+	if gotA != "1.0.0-rc.2" {
+		t.Errorf("module-a version = %q, want %q", gotA, "1.0.0-rc.2")
+	}
+	if gotB != "2.0.0-rc.6" {
+		t.Errorf("module-b version = %q, want %q", gotB, "2.0.0-rc.6")
+	}
+
+	// Verify output contains increment operation name
+	if !strings.Contains(output, "Increment pre-release with rc") {
+		t.Errorf("expected increment operation name in output, got: %q", output)
+	}
+}
+
+func TestCLI_PreCommand_MultiModule_Specific(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	// Create multi-module workspace
+	moduleA := filepath.Join(tmpDir, "module-a")
+	moduleB := filepath.Join(tmpDir, "module-b")
+	if err := os.MkdirAll(moduleA, 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(moduleB, 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	testutils.WriteTempVersionFile(t, moduleA, "1.0.0")
+	testutils.WriteTempVersionFile(t, moduleB, "2.0.0")
+
+	// Create config with workspace discovery enabled
+	enabled := true
+	recursive := true
+	maxDepth := 10
+	cfg := &config.Config{
+		Path: ".version",
+		Workspace: &config.WorkspaceConfig{
+			Discovery: &config.DiscoveryConfig{
+				Enabled:   &enabled,
+				Recursive: &recursive,
+				MaxDepth:  &maxDepth,
+			},
+		},
+	}
+
+	appCli := testutils.BuildCLIForTests(cfg.Path, []*cli.Command{Run(cfg)})
+
+	// Test with --module flag to target specific module
+	testutils.RunCLITest(t, appCli, []string{"sley", "pre", "--label", "alpha", "--module", "module-a"}, tmpDir)
+
+	// Verify only module-a was updated
+	gotA := testutils.ReadTempVersionFile(t, moduleA)
+	gotB := testutils.ReadTempVersionFile(t, moduleB)
+
+	if gotA != "1.0.1-alpha" {
+		t.Errorf("module-a version = %q, want %q", gotA, "1.0.1-alpha")
+	}
+	if gotB != "2.0.0" {
+		t.Errorf("module-b should remain %q, got %q", "2.0.0", gotB)
+	}
+}
+
+func TestCLI_PreCommand_MultiModule_Quiet(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	// Create multi-module workspace
+	moduleA := filepath.Join(tmpDir, "module-a")
+	moduleB := filepath.Join(tmpDir, "module-b")
+	if err := os.MkdirAll(moduleA, 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(moduleB, 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	testutils.WriteTempVersionFile(t, moduleA, "1.0.0")
+	testutils.WriteTempVersionFile(t, moduleB, "2.0.0")
+
+	// Create config with workspace discovery enabled
+	enabled := true
+	recursive := true
+	maxDepth := 10
+	cfg := &config.Config{
+		Path: ".version",
+		Workspace: &config.WorkspaceConfig{
+			Discovery: &config.DiscoveryConfig{
+				Enabled:   &enabled,
+				Recursive: &recursive,
+				MaxDepth:  &maxDepth,
+			},
+		},
+	}
+
+	appCli := testutils.BuildCLIForTests(cfg.Path, []*cli.Command{Run(cfg)})
+
+	// Test with --quiet flag
+	output, err := testutils.CaptureStdout(func() {
+		testutils.RunCLITest(t, appCli, []string{"sley", "pre", "--label", "rc", "--all", "--quiet"}, tmpDir)
+	})
+	if err != nil {
+		t.Fatalf("Failed to capture stdout: %v", err)
+	}
+
+	// Quiet mode should show minimal output
+	if !strings.Contains(output, "Success:") && !strings.Contains(output, "2 module(s)") {
+		t.Errorf("expected quiet summary, got: %q", output)
+	}
+
+	// Verify versions were still updated
+	gotA := testutils.ReadTempVersionFile(t, moduleA)
+	gotB := testutils.ReadTempVersionFile(t, moduleB)
+
+	if gotA != "1.0.1-rc" || gotB != "2.0.1-rc" {
+		t.Errorf("modules not updated correctly: module-a=%q, module-b=%q", gotA, gotB)
+	}
+}
+
+func TestCLI_PreCommand_MultiModule_JSONFormat(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	// Create multi-module workspace
+	moduleA := filepath.Join(tmpDir, "module-a")
+	moduleB := filepath.Join(tmpDir, "module-b")
+	if err := os.MkdirAll(moduleA, 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(moduleB, 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	testutils.WriteTempVersionFile(t, moduleA, "1.0.0")
+	testutils.WriteTempVersionFile(t, moduleB, "2.0.0")
+
+	// Create config with workspace discovery enabled
+	enabled := true
+	recursive := true
+	maxDepth := 10
+	cfg := &config.Config{
+		Path: ".version",
+		Workspace: &config.WorkspaceConfig{
+			Discovery: &config.DiscoveryConfig{
+				Enabled:   &enabled,
+				Recursive: &recursive,
+				MaxDepth:  &maxDepth,
+			},
+		},
+	}
+
+	appCli := testutils.BuildCLIForTests(cfg.Path, []*cli.Command{Run(cfg)})
+
+	// Test with --format json
+	output, err := testutils.CaptureStdout(func() {
+		testutils.RunCLITest(t, appCli, []string{"sley", "pre", "--label", "beta", "--all", "--format", "json"}, tmpDir)
+	})
+	if err != nil {
+		t.Fatalf("Failed to capture stdout: %v", err)
+	}
+
+	// Output should contain JSON with module names
+	if !strings.Contains(output, "module-a") || !strings.Contains(output, "module-b") {
+		t.Errorf("expected JSON output with module names, got: %q", output)
+	}
+}
+
+func TestCLI_PreCommand_MultiModule_Parallel(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	// Create multi-module workspace with 3 modules
+	moduleA := filepath.Join(tmpDir, "module-a")
+	moduleB := filepath.Join(tmpDir, "module-b")
+	moduleC := filepath.Join(tmpDir, "module-c")
+	if err := os.MkdirAll(moduleA, 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(moduleB, 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(moduleC, 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	testutils.WriteTempVersionFile(t, moduleA, "1.0.0")
+	testutils.WriteTempVersionFile(t, moduleB, "2.0.0")
+	testutils.WriteTempVersionFile(t, moduleC, "3.0.0")
+
+	// Create config with workspace discovery enabled
+	enabled := true
+	recursive := true
+	maxDepth := 10
+	cfg := &config.Config{
+		Path: ".version",
+		Workspace: &config.WorkspaceConfig{
+			Discovery: &config.DiscoveryConfig{
+				Enabled:   &enabled,
+				Recursive: &recursive,
+				MaxDepth:  &maxDepth,
+			},
+		},
+	}
+
+	appCli := testutils.BuildCLIForTests(cfg.Path, []*cli.Command{Run(cfg)})
+
+	// Test with --parallel flag
+	testutils.RunCLITest(t, appCli, []string{"sley", "pre", "--label", "alpha", "--all", "--parallel"}, tmpDir)
+
+	// Verify all modules were updated
+	gotA := testutils.ReadTempVersionFile(t, moduleA)
+	gotB := testutils.ReadTempVersionFile(t, moduleB)
+	gotC := testutils.ReadTempVersionFile(t, moduleC)
+
+	if gotA != "1.0.1-alpha" || gotB != "2.0.1-alpha" || gotC != "3.0.1-alpha" {
+		t.Errorf("modules not all updated: a=%q, b=%q, c=%q", gotA, gotB, gotC)
+	}
+}
+
+func TestCLI_PreCommand_MultiModule_TextFormat(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	// Create multi-module workspace
+	moduleA := filepath.Join(tmpDir, "module-a")
+	moduleB := filepath.Join(tmpDir, "module-b")
+	if err := os.MkdirAll(moduleA, 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(moduleB, 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	testutils.WriteTempVersionFile(t, moduleA, "1.0.0")
+	testutils.WriteTempVersionFile(t, moduleB, "2.0.0")
+
+	// Create config with workspace discovery enabled
+	enabled := true
+	recursive := true
+	maxDepth := 10
+	cfg := &config.Config{
+		Path: ".version",
+		Workspace: &config.WorkspaceConfig{
+			Discovery: &config.DiscoveryConfig{
+				Enabled:   &enabled,
+				Recursive: &recursive,
+				MaxDepth:  &maxDepth,
+			},
+		},
+	}
+
+	appCli := testutils.BuildCLIForTests(cfg.Path, []*cli.Command{Run(cfg)})
+
+	// Test with --format text
+	output, err := testutils.CaptureStdout(func() {
+		testutils.RunCLITest(t, appCli, []string{"sley", "pre", "--label", "rc", "--all", "--format", "text"}, tmpDir)
+	})
+	if err != nil {
+		t.Fatalf("Failed to capture stdout: %v", err)
+	}
+
+	// Verify text format output
+	if !strings.Contains(output, "module-a") || !strings.Contains(output, "module-b") {
+		t.Errorf("expected text output with module names, got: %q", output)
+	}
+}
+
+/* ------------------------------------------------------------------------- */
+/* PRINT QUIET SUMMARY TESTS                                                */
+/* ------------------------------------------------------------------------- */
+
+func TestPrintQuietSummary(t *testing.T) {
+	tests := []struct {
+		name     string
+		results  []workspace.ExecutionResult
+		expected string
+	}{
+		{
+			name: "all success",
+			results: []workspace.ExecutionResult{
+				{Module: &workspace.Module{Name: "mod1"}, Success: true},
+				{Module: &workspace.Module{Name: "mod2"}, Success: true},
+			},
+			expected: "Success: 2 module(s) updated",
+		},
+		{
+			name: "with failures",
+			results: []workspace.ExecutionResult{
+				{Module: &workspace.Module{Name: "mod1"}, Success: true},
+				{Module: &workspace.Module{Name: "mod2"}, Success: false, Error: fmt.Errorf("failed")},
+			},
+			expected: "Completed: 1 succeeded, 1 failed",
+		},
+		{
+			name: "all failures",
+			results: []workspace.ExecutionResult{
+				{Module: &workspace.Module{Name: "mod1"}, Success: false, Error: fmt.Errorf("error1")},
+				{Module: &workspace.Module{Name: "mod2"}, Success: false, Error: fmt.Errorf("error2")},
+			},
+			expected: "Completed: 0 succeeded, 2 failed",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			output, _ := testutils.CaptureStdout(func() {
+				printQuietSummary(tt.results)
+			})
+			if !strings.Contains(output, tt.expected) {
+				t.Errorf("expected output to contain %q, got %q", tt.expected, output)
+			}
+		})
 	}
 }

--- a/internal/operations/pre.go
+++ b/internal/operations/pre.go
@@ -1,0 +1,83 @@
+package operations
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/indaco/sley/internal/core"
+	"github.com/indaco/sley/internal/semver"
+	"github.com/indaco/sley/internal/workspace"
+)
+
+// PreOperation sets or increments pre-release labels on a module.
+type PreOperation struct {
+	fs        core.FileSystem
+	label     string
+	increment bool
+}
+
+// NewPreOperation creates a new pre-release operation.
+func NewPreOperation(fs core.FileSystem, label string, increment bool) *PreOperation {
+	return &PreOperation{
+		fs:        fs,
+		label:     label,
+		increment: increment,
+	}
+}
+
+// Execute performs the pre-release operation on the module.
+func (op *PreOperation) Execute(ctx context.Context, mod *workspace.Module) error {
+	// Check for context cancellation
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	default:
+	}
+
+	// Create version manager
+	vm := semver.NewVersionManager(op.fs, nil)
+
+	// Read current version
+	currentVer, err := vm.Read(mod.Path)
+	if err != nil {
+		return fmt.Errorf("failed to read version from %s: %w", mod.Path, err)
+	}
+
+	// Store old version for display
+	oldVersion := currentVer.String()
+
+	// Create new version
+	newVer := currentVer
+
+	if op.increment {
+		newVer.PreRelease = semver.IncrementPreRelease(currentVer.PreRelease, op.label)
+	} else {
+		// If there's no existing pre-release, bump patch first
+		if currentVer.PreRelease == "" {
+			newVer.Patch++
+		}
+		newVer.PreRelease = op.label
+	}
+
+	// Write the new version
+	if err := vm.Save(mod.Path, newVer); err != nil {
+		return fmt.Errorf("failed to write version to %s: %w", mod.Path, err)
+	}
+
+	// Update module's current version for display (set both old and new for output)
+	mod.CurrentVersion = newVer.String()
+	// Store old version in a custom field if workspace module supports it
+	// For now, we rely on the workspace executor to capture the old version before Execute
+
+	_ = oldVersion // For potential logging
+
+	return nil
+}
+
+// Name returns the name of this operation.
+func (op *PreOperation) Name() string {
+	if op.increment {
+		return "increment pre-release"
+	}
+	return "set pre-release"
+}

--- a/internal/operations/pre_test.go
+++ b/internal/operations/pre_test.go
@@ -1,0 +1,354 @@
+package operations
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/indaco/sley/internal/core"
+	"github.com/indaco/sley/internal/workspace"
+)
+
+func TestNewPreOperation(t *testing.T) {
+	fs := core.NewMockFileSystem()
+	op := NewPreOperation(fs, "alpha", true)
+
+	if op == nil {
+		t.Fatal("NewPreOperation returned nil")
+	}
+	if op.fs == nil {
+		t.Error("fs is nil")
+	}
+	if op.label != "alpha" {
+		t.Errorf("label = %v, want %v", op.label, "alpha")
+	}
+	if !op.increment {
+		t.Error("increment should be true")
+	}
+}
+
+func TestPreOperation_Execute_SetLabel(t *testing.T) {
+	tests := []struct {
+		name     string
+		initial  string
+		label    string
+		expected string
+	}{
+		{
+			name:     "set label on stable version",
+			initial:  "1.2.3\n",
+			label:    "alpha",
+			expected: "1.2.4-alpha\n",
+		},
+		{
+			name:     "set label on version with existing pre-release",
+			initial:  "1.2.3-beta.1\n",
+			label:    "alpha",
+			expected: "1.2.3-alpha\n",
+		},
+		{
+			name:     "set rc label",
+			initial:  "2.0.0\n",
+			label:    "rc",
+			expected: "2.0.1-rc\n",
+		},
+		{
+			name:     "set beta.1 label",
+			initial:  "0.1.0\n",
+			label:    "beta.1",
+			expected: "0.1.1-beta.1\n",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			fs := core.NewMockFileSystem()
+			fs.SetFile("/test/.version", []byte(tt.initial))
+
+			op := NewPreOperation(fs, tt.label, false)
+			mod := &workspace.Module{
+				Name: "test",
+				Path: "/test/.version",
+			}
+
+			ctx := context.Background()
+			err := op.Execute(ctx, mod)
+			if err != nil {
+				t.Fatalf("Execute failed: %v", err)
+			}
+
+			data, ok := fs.GetFile("/test/.version")
+			if !ok {
+				t.Fatal("version file not found")
+			}
+
+			if string(data) != tt.expected {
+				t.Errorf("version = %q, want %q", string(data), tt.expected)
+			}
+		})
+	}
+}
+
+func TestPreOperation_Execute_IncrementLabel(t *testing.T) {
+	tests := []struct {
+		name     string
+		initial  string
+		label    string
+		expected string
+	}{
+		{
+			name:     "increment existing alpha.1",
+			initial:  "1.2.3-alpha.1\n",
+			label:    "alpha",
+			expected: "1.2.3-alpha.2\n",
+		},
+		{
+			name:     "increment existing rc.5",
+			initial:  "2.0.0-rc.5\n",
+			label:    "rc",
+			expected: "2.0.0-rc.6\n",
+		},
+		{
+			name:     "increment base label without number",
+			initial:  "1.0.0-beta\n",
+			label:    "beta",
+			expected: "1.0.0-beta.1\n",
+		},
+		{
+			name:     "increment with different base creates new label",
+			initial:  "1.2.3-alpha.1\n",
+			label:    "beta",
+			expected: "1.2.3-beta.1\n",
+		},
+		{
+			name:     "increment from stable version",
+			initial:  "1.2.3\n",
+			label:    "alpha",
+			expected: "1.2.3-alpha.1\n",
+		},
+		{
+			name:     "increment with dash separator",
+			initial:  "1.0.0-rc-1\n",
+			label:    "rc",
+			expected: "1.0.0-rc-2\n",
+		},
+		{
+			name:     "increment with no separator",
+			initial:  "1.0.0-rc1\n",
+			label:    "rc",
+			expected: "1.0.0-rc2\n",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			fs := core.NewMockFileSystem()
+			fs.SetFile("/test/.version", []byte(tt.initial))
+
+			op := NewPreOperation(fs, tt.label, true)
+			mod := &workspace.Module{
+				Name: "test",
+				Path: "/test/.version",
+			}
+
+			ctx := context.Background()
+			err := op.Execute(ctx, mod)
+			if err != nil {
+				t.Fatalf("Execute failed: %v", err)
+			}
+
+			data, ok := fs.GetFile("/test/.version")
+			if !ok {
+				t.Fatal("version file not found")
+			}
+
+			if string(data) != tt.expected {
+				t.Errorf("version = %q, want %q", string(data), tt.expected)
+			}
+		})
+	}
+}
+
+func TestPreOperation_Execute_UpdatesModuleVersion(t *testing.T) {
+	fs := core.NewMockFileSystem()
+	fs.SetFile("/test/.version", []byte("1.2.3\n"))
+
+	op := NewPreOperation(fs, "alpha", false)
+	mod := &workspace.Module{
+		Name: "test",
+		Path: "/test/.version",
+	}
+
+	ctx := context.Background()
+	err := op.Execute(ctx, mod)
+	if err != nil {
+		t.Fatalf("Execute failed: %v", err)
+	}
+
+	if mod.CurrentVersion != "1.2.4-alpha" {
+		t.Errorf("module CurrentVersion = %q, want %q", mod.CurrentVersion, "1.2.4-alpha")
+	}
+}
+
+func TestPreOperation_Execute_ContextCancellation(t *testing.T) {
+	fs := core.NewMockFileSystem()
+	fs.SetFile("/test/.version", []byte("1.2.3\n"))
+
+	op := NewPreOperation(fs, "alpha", false)
+	mod := &workspace.Module{
+		Name: "test",
+		Path: "/test/.version",
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // Cancel immediately
+
+	err := op.Execute(ctx, mod)
+	if err == nil {
+		t.Fatal("expected context cancellation error, got nil")
+	}
+	if err != context.Canceled {
+		t.Errorf("expected context.Canceled, got %v", err)
+	}
+}
+
+func TestPreOperation_Execute_ContextTimeout(t *testing.T) {
+	fs := core.NewMockFileSystem()
+	fs.SetFile("/test/.version", []byte("1.2.3\n"))
+
+	op := NewPreOperation(fs, "alpha", false)
+	mod := &workspace.Module{
+		Name: "test",
+		Path: "/test/.version",
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Nanosecond)
+	defer cancel()
+
+	time.Sleep(2 * time.Millisecond)
+
+	err := op.Execute(ctx, mod)
+	if err == nil {
+		t.Fatal("expected context timeout error, got nil")
+	}
+}
+
+func TestPreOperation_Execute_ReadError(t *testing.T) {
+	fs := core.NewMockFileSystem()
+	// Don't set any file, so read will fail
+
+	op := NewPreOperation(fs, "alpha", false)
+	mod := &workspace.Module{
+		Name: "test",
+		Path: "/test/.version",
+	}
+
+	ctx := context.Background()
+	err := op.Execute(ctx, mod)
+	if err == nil {
+		t.Fatal("expected read error, got nil")
+	}
+}
+
+func TestPreOperation_Execute_SaveError(t *testing.T) {
+	fs := core.NewMockFileSystem()
+	fs.SetFile("/test/.version", []byte("1.2.3\n"))
+
+	// Inject write error - this will be checked when Save is called
+	fs.WriteErr = context.DeadlineExceeded
+
+	op := NewPreOperation(fs, "alpha", false)
+	mod := &workspace.Module{
+		Name: "test",
+		Path: "/test/.version",
+	}
+
+	ctx := context.Background()
+
+	err := op.Execute(ctx, mod)
+	if err == nil {
+		t.Fatal("expected save error, got nil")
+	}
+}
+
+func TestPreOperation_Name(t *testing.T) {
+	tests := []struct {
+		name      string
+		increment bool
+		expected  string
+	}{
+		{
+			name:      "set pre-release name",
+			increment: false,
+			expected:  "set pre-release",
+		},
+		{
+			name:      "increment pre-release name",
+			increment: true,
+			expected:  "increment pre-release",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			fs := core.NewMockFileSystem()
+			op := NewPreOperation(fs, "alpha", tt.increment)
+
+			name := op.Name()
+			if name != tt.expected {
+				t.Errorf("Name() = %q, want %q", name, tt.expected)
+			}
+		})
+	}
+}
+
+func TestPreOperation_Execute_WithBuildMetadata(t *testing.T) {
+	tests := []struct {
+		name     string
+		initial  string
+		label    string
+		expected string
+	}{
+		{
+			name:     "set preserves build metadata",
+			initial:  "1.2.3+build.123\n",
+			label:    "alpha",
+			expected: "1.2.4-alpha+build.123\n", // Build metadata is preserved from read
+		},
+		{
+			name:     "increment preserves build metadata",
+			initial:  "1.2.3-alpha.1+build.123\n",
+			label:    "alpha",
+			expected: "1.2.3-alpha.2+build.123\n", // Build metadata is preserved from read
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			fs := core.NewMockFileSystem()
+			fs.SetFile("/test/.version", []byte(tt.initial))
+
+			increment := tt.name == "increment preserves build metadata"
+			op := NewPreOperation(fs, tt.label, increment)
+			mod := &workspace.Module{
+				Name: "test",
+				Path: "/test/.version",
+			}
+
+			ctx := context.Background()
+			err := op.Execute(ctx, mod)
+			if err != nil {
+				t.Fatalf("Execute failed: %v", err)
+			}
+
+			data, ok := fs.GetFile("/test/.version")
+			if !ok {
+				t.Fatal("version file not found")
+			}
+
+			if string(data) != tt.expected {
+				t.Errorf("version = %q, want %q", string(data), tt.expected)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary


- Add multi-module support to `sley pre` command
- Create PreOperation for workspace execution
- Support setting and incrementing pre-release labels across modules
- Parallel execution support