### PR TITLE
fix(security): add path traversal validation and race testing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -82,3 +82,33 @@ jobs:
 
       - name: Run test
         run: just test
+
+  test-race:
+    name: test-race
+    runs-on: ubuntu-latest
+    needs: lint
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      - name: Set up Go
+        uses: actions/setup-go@v6
+        with:
+          go-version: ${{ env.GO_VERSION }}
+          cache-dependency-path: go.sum
+          check-latest: true
+
+      - name: Install Go modules
+        run: go mod download
+
+      - name: Verify dependencies
+        run: go mod verify
+
+      - name: Install just
+        uses: taiki-e/install-action@v2
+        with:
+          tool: just
+
+      - name: Run tests with race detector
+        run: just test-race

--- a/justfile
+++ b/justfile
@@ -73,6 +73,11 @@ test-coverage:
     @echo "* Run all tests and generate coverage report."
     go test -count=1 -timeout 30s $(go list ./... | grep -Ev 'internal/testutils') -covermode=atomic -coverprofile=coverage.txt
 
+# Run all tests with race detector
+test-race:
+    @echo "* Running tests with race detector..."
+    {{ go }} test -race $({{ go }} list ./... | grep -Ev 'internal/testutils')
+
 # Run modernize, lint, and reportcard
 check: modernize lint reportcard
 


### PR DESCRIPTION
## Summary

1. Path Traversal Security:
   - Add path validation to ExecuteExtensionHook to prevent directory traversal attacks
   - Use existing pathutil.ValidatePath to ensure scripts stay within extension directory
   - Add more tests for path traversal attempts
   - Improve error messages with more context

2. Race Condition Testing:
   - Add 'test-race' recipe to justfile for running tests with race detector
   - Add test-race job to CI workflow for systematic race detection