### PR TITLE
refactor: error message context enhancement

### DIFF
--- a/internal/extensionmgr/register.go
+++ b/internal/extensionmgr/register.go
@@ -18,16 +18,16 @@ func registerLocalExtension(localPath, configPath, extensionDirectory string) er
 	// 1. Validate source path (ensure it's a directory)
 	info, err := os.Stat(localPath)
 	if err != nil {
-		return fmt.Errorf("extension path error: %w", err)
+		return fmt.Errorf("extension path %q error: %w", localPath, err)
 	}
 	if !info.IsDir() {
-		return fmt.Errorf("extension path must be a directory")
+		return fmt.Errorf("extension path %q must be a directory", localPath)
 	}
 
 	// 2. Load and validate the extension manifest
 	manifest, err := extensions.LoadExtensionManifestFn(localPath)
 	if err != nil {
-		return fmt.Errorf("failed to load extension manifest: %w", err)
+		return fmt.Errorf("failed to load extension manifest from %q: %w", localPath, err)
 	}
 
 	// 3. Resolve base extension directory
@@ -63,7 +63,7 @@ Then run this command again.
 
 	// 5. Copy the extension files to the destination directory
 	if err := copyDirFn(localPath, destPath); err != nil {
-		return fmt.Errorf("failed to copy extension files: %w", err)
+		return fmt.Errorf("failed to copy extension files from %q to %q: %w", localPath, destPath, err)
 	}
 
 	// 6. Update the config
@@ -75,7 +75,7 @@ Then run this command again.
 
 	// 7. Add the extension to the config file
 	if err := AddExtensionToConfigFn(absConfigPath, extensionCfg); err != nil {
-		return fmt.Errorf("failed to update config: %w", err)
+		return fmt.Errorf("failed to update config %q: %w", absConfigPath, err)
 	}
 
 	// 8. Success message

--- a/internal/extensionmgr/register_test.go
+++ b/internal/extensionmgr/register_test.go
@@ -57,8 +57,8 @@ entry: extension.go
 func TestRegisterLocalExtension_InvalidPath(t *testing.T) {
 	tmpDir := os.TempDir()
 	err := RegisterLocalExtensionFn("/nonexistent/path", ".sley.yaml", tmpDir)
-	if err == nil || !strings.Contains(err.Error(), "extension path error") {
-		t.Errorf("extension extension path error, got: %v", err)
+	if err == nil || !strings.Contains(err.Error(), "extension path") {
+		t.Errorf("expected extension path error, got: %v", err)
 	}
 }
 

--- a/internal/plugins/auditlog/auditlog.go
+++ b/internal/plugins/auditlog/auditlog.go
@@ -197,12 +197,12 @@ func (p *AuditLogPlugin) readLogFile() (*AuditLogFile, error) {
 
 	data, err := p.fileOps.ReadFile(path)
 	if err != nil {
-		return nil, fmt.Errorf("failed to read file: %w", err)
+		return nil, fmt.Errorf("failed to read audit log %q: %w", path, err)
 	}
 
 	var logFile AuditLogFile
 	if err := p.unmarshalFn(data, &logFile); err != nil {
-		return nil, fmt.Errorf("failed to unmarshal: %w", err)
+		return nil, fmt.Errorf("failed to parse audit log %q: %w", path, err)
 	}
 
 	return &logFile, nil
@@ -212,12 +212,12 @@ func (p *AuditLogPlugin) readLogFile() (*AuditLogFile, error) {
 func (p *AuditLogPlugin) writeLogFile(logFile *AuditLogFile) error {
 	data, err := p.marshalFn(logFile)
 	if err != nil {
-		return fmt.Errorf("failed to marshal: %w", err)
+		return fmt.Errorf("failed to marshal audit log: %w", err)
 	}
 
 	path := p.config.GetPath()
 	if err := p.fileOps.WriteFile(path, data, 0644); err != nil {
-		return fmt.Errorf("failed to write file: %w", err)
+		return fmt.Errorf("failed to write audit log %q: %w", path, err)
 	}
 
 	return nil

--- a/internal/plugins/changeloggenerator/generator.go
+++ b/internal/plugins/changeloggenerator/generator.go
@@ -208,7 +208,7 @@ func (g *Generator) writeContributorEntry(sb *strings.Builder, contrib Contribut
 func (g *Generator) WriteVersionedFile(version, content string) error {
 	dir := g.config.ChangesDir
 	if err := os.MkdirAll(dir, 0755); err != nil {
-		return fmt.Errorf("failed to create changes directory: %w", err)
+		return fmt.Errorf("failed to create changes directory %q: %w", dir, err)
 	}
 
 	filename := fmt.Sprintf("%s.md", version)
@@ -218,7 +218,7 @@ func (g *Generator) WriteVersionedFile(version, content string) error {
 	normalizedContent := strings.TrimRight(content, "\n\r\t ") + "\n"
 
 	if err := os.WriteFile(path, []byte(normalizedContent), 0644); err != nil {
-		return fmt.Errorf("failed to write changelog file: %w", err)
+		return fmt.Errorf("failed to write changelog file %q: %w", path, err)
 	}
 
 	return nil
@@ -250,7 +250,7 @@ func (g *Generator) WriteUnifiedChangelog(newContent string) error {
 	finalContent = strings.TrimRight(finalContent, "\n\r\t ") + "\n"
 
 	if err := os.WriteFile(path, []byte(finalContent), 0644); err != nil {
-		return fmt.Errorf("failed to write changelog: %w", err)
+		return fmt.Errorf("failed to write changelog %q: %w", path, err)
 	}
 
 	return nil
@@ -308,7 +308,7 @@ func (g *Generator) MergeVersionedFiles() error {
 	// Read all version files
 	entries, err := os.ReadDir(dir)
 	if err != nil {
-		return fmt.Errorf("failed to read changes directory: %w", err)
+		return fmt.Errorf("failed to read changes directory %q: %w", dir, err)
 	}
 
 	// Collect version files (excluding header template and directories)
@@ -354,7 +354,7 @@ func (g *Generator) MergeVersionedFiles() error {
 	// Normalize: trim trailing whitespace and ensure single trailing newline
 	finalContent := strings.TrimRight(sb.String(), "\n\r\t ") + "\n"
 	if err := os.WriteFile(path, []byte(finalContent), 0644); err != nil {
-		return fmt.Errorf("failed to write unified changelog: %w", err)
+		return fmt.Errorf("failed to write unified changelog %q: %w", path, err)
 	}
 
 	return nil

--- a/internal/plugins/dependencycheck/parsers.go
+++ b/internal/plugins/dependencycheck/parsers.go
@@ -32,22 +32,22 @@ var (
 func readJSONVersion(path, field string) (string, error) {
 	data, err := readFileFn(path)
 	if err != nil {
-		return "", fmt.Errorf("failed to read file: %w", err)
+		return "", fmt.Errorf("failed to read file %q: %w", path, err)
 	}
 
 	var obj map[string]any
 	if err := json.Unmarshal(data, &obj); err != nil {
-		return "", fmt.Errorf("failed to parse JSON: %w", err)
+		return "", fmt.Errorf("failed to parse JSON in %q: %w", path, err)
 	}
 
 	value, err := getNestedValue(obj, field)
 	if err != nil {
-		return "", err
+		return "", fmt.Errorf("in file %q: %w", path, err)
 	}
 
 	version, ok := value.(string)
 	if !ok {
-		return "", fmt.Errorf("field %q is not a string", field)
+		return "", fmt.Errorf("field %q in %q is not a string", field, path)
 	}
 
 	return version, nil
@@ -57,29 +57,29 @@ func readJSONVersion(path, field string) (string, error) {
 func writeJSONVersion(path, field, version string) error {
 	data, err := readFileFn(path)
 	if err != nil {
-		return fmt.Errorf("failed to read file: %w", err)
+		return fmt.Errorf("failed to read file %q: %w", path, err)
 	}
 
 	var obj map[string]any
 	if err := json.Unmarshal(data, &obj); err != nil {
-		return fmt.Errorf("failed to parse JSON: %w", err)
+		return fmt.Errorf("failed to parse JSON in %q: %w", path, err)
 	}
 
 	if err := setNestedValue(obj, field, version); err != nil {
-		return err
+		return fmt.Errorf("in file %q: %w", path, err)
 	}
 
 	// Marshal with indentation for readability
 	updated, err := json.MarshalIndent(obj, "", "  ")
 	if err != nil {
-		return fmt.Errorf("failed to marshal JSON: %w", err)
+		return fmt.Errorf("failed to marshal JSON for %q: %w", path, err)
 	}
 
 	// Add trailing newline
 	updated = append(updated, '\n')
 
 	if err := writeFileFn(path, updated, 0644); err != nil {
-		return fmt.Errorf("failed to write file: %w", err)
+		return fmt.Errorf("failed to write file %q: %w", path, err)
 	}
 
 	return nil
@@ -89,22 +89,22 @@ func writeJSONVersion(path, field, version string) error {
 func readYAMLVersion(path, field string) (string, error) {
 	data, err := readFileFn(path)
 	if err != nil {
-		return "", fmt.Errorf("failed to read file: %w", err)
+		return "", fmt.Errorf("failed to read file %q: %w", path, err)
 	}
 
 	var obj map[string]any
 	if err := yaml.Unmarshal(data, &obj); err != nil {
-		return "", fmt.Errorf("failed to parse YAML: %w", err)
+		return "", fmt.Errorf("failed to parse YAML in %q: %w", path, err)
 	}
 
 	value, err := getNestedValue(obj, field)
 	if err != nil {
-		return "", err
+		return "", fmt.Errorf("in file %q: %w", path, err)
 	}
 
 	version, ok := value.(string)
 	if !ok {
-		return "", fmt.Errorf("field %q is not a string", field)
+		return "", fmt.Errorf("field %q in %q is not a string", field, path)
 	}
 
 	return version, nil
@@ -114,25 +114,25 @@ func readYAMLVersion(path, field string) (string, error) {
 func writeYAMLVersion(path, field, version string) error {
 	data, err := readFileFn(path)
 	if err != nil {
-		return fmt.Errorf("failed to read file: %w", err)
+		return fmt.Errorf("failed to read file %q: %w", path, err)
 	}
 
 	var obj map[string]any
 	if err := yaml.Unmarshal(data, &obj); err != nil {
-		return fmt.Errorf("failed to parse YAML: %w", err)
+		return fmt.Errorf("failed to parse YAML in %q: %w", path, err)
 	}
 
 	if err := setNestedValue(obj, field, version); err != nil {
-		return err
+		return fmt.Errorf("in file %q: %w", path, err)
 	}
 
 	updated, err := yaml.Marshal(obj)
 	if err != nil {
-		return fmt.Errorf("failed to marshal YAML: %w", err)
+		return fmt.Errorf("failed to marshal YAML for %q: %w", path, err)
 	}
 
 	if err := writeFileFn(path, updated, 0644); err != nil {
-		return fmt.Errorf("failed to write file: %w", err)
+		return fmt.Errorf("failed to write file %q: %w", path, err)
 	}
 
 	return nil
@@ -142,22 +142,22 @@ func writeYAMLVersion(path, field, version string) error {
 func readTOMLVersion(path, field string) (string, error) {
 	data, err := readFileFn(path)
 	if err != nil {
-		return "", fmt.Errorf("failed to read file: %w", err)
+		return "", fmt.Errorf("failed to read file %q: %w", path, err)
 	}
 
 	var obj map[string]any
 	if err := toml.Unmarshal(data, &obj); err != nil {
-		return "", fmt.Errorf("failed to parse TOML: %w", err)
+		return "", fmt.Errorf("failed to parse TOML in %q: %w", path, err)
 	}
 
 	value, err := getNestedValue(obj, field)
 	if err != nil {
-		return "", err
+		return "", fmt.Errorf("in file %q: %w", path, err)
 	}
 
 	version, ok := value.(string)
 	if !ok {
-		return "", fmt.Errorf("field %q is not a string", field)
+		return "", fmt.Errorf("field %q in %q is not a string", field, path)
 	}
 
 	return version, nil
@@ -167,25 +167,25 @@ func readTOMLVersion(path, field string) (string, error) {
 func writeTOMLVersion(path, field, version string) error {
 	data, err := readFileFn(path)
 	if err != nil {
-		return fmt.Errorf("failed to read file: %w", err)
+		return fmt.Errorf("failed to read file %q: %w", path, err)
 	}
 
 	var obj map[string]any
 	if err := toml.Unmarshal(data, &obj); err != nil {
-		return fmt.Errorf("failed to parse TOML: %w", err)
+		return fmt.Errorf("failed to parse TOML in %q: %w", path, err)
 	}
 
 	if err := setNestedValue(obj, field, version); err != nil {
-		return err
+		return fmt.Errorf("in file %q: %w", path, err)
 	}
 
 	updated, err := toml.Marshal(obj)
 	if err != nil {
-		return fmt.Errorf("failed to marshal TOML: %w", err)
+		return fmt.Errorf("failed to marshal TOML for %q: %w", path, err)
 	}
 
 	if err := writeFileFn(path, updated, 0644); err != nil {
-		return fmt.Errorf("failed to write file: %w", err)
+		return fmt.Errorf("failed to write file %q: %w", path, err)
 	}
 
 	return nil
@@ -195,7 +195,7 @@ func writeTOMLVersion(path, field, version string) error {
 func readRawVersion(path string) (string, error) {
 	data, err := readFileFn(path)
 	if err != nil {
-		return "", fmt.Errorf("failed to read file: %w", err)
+		return "", fmt.Errorf("failed to read file %q: %w", path, err)
 	}
 
 	return strings.TrimSpace(string(data)), nil
@@ -210,7 +210,7 @@ func writeRawVersion(path, version string) error {
 	}
 
 	if err := writeFileFn(path, []byte(content), 0644); err != nil {
-		return fmt.Errorf("failed to write file: %w", err)
+		return fmt.Errorf("failed to write file %q: %w", path, err)
 	}
 
 	return nil
@@ -220,17 +220,17 @@ func writeRawVersion(path, version string) error {
 func readRegexVersion(path, pattern string) (string, error) {
 	data, err := readFileFn(path)
 	if err != nil {
-		return "", fmt.Errorf("failed to read file: %w", err)
+		return "", fmt.Errorf("failed to read file %q: %w", path, err)
 	}
 
 	re, err := regexp.Compile(pattern)
 	if err != nil {
-		return "", fmt.Errorf("invalid regex pattern: %w", err)
+		return "", fmt.Errorf("invalid regex pattern %q: %w", pattern, err)
 	}
 
 	matches := re.FindSubmatch(data)
 	if len(matches) < 2 {
-		return "", fmt.Errorf("no version match found (pattern must have capturing group)")
+		return "", fmt.Errorf("no version match found in %q (pattern %q must have capturing group)", path, pattern)
 	}
 
 	return string(matches[1]), nil
@@ -240,17 +240,17 @@ func readRegexVersion(path, pattern string) (string, error) {
 func writeRegexVersion(path, pattern, version string) error {
 	data, err := readFileFn(path)
 	if err != nil {
-		return fmt.Errorf("failed to read file: %w", err)
+		return fmt.Errorf("failed to read file %q: %w", path, err)
 	}
 
 	re, err := regexp.Compile(pattern)
 	if err != nil {
-		return fmt.Errorf("invalid regex pattern: %w", err)
+		return fmt.Errorf("invalid regex pattern %q: %w", pattern, err)
 	}
 
 	// Find the first match to ensure pattern is valid
 	if !re.Match(data) {
-		return fmt.Errorf("pattern does not match file contents")
+		return fmt.Errorf("pattern %q does not match contents of %q", pattern, path)
 	}
 
 	// Replace using ReplaceAllFunc to preserve surrounding text
@@ -265,7 +265,7 @@ func writeRegexVersion(path, pattern, version string) error {
 	})
 
 	if err := writeFileFn(path, updated, 0644); err != nil {
-		return fmt.Errorf("failed to write file: %w", err)
+		return fmt.Errorf("failed to write file %q: %w", path, err)
 	}
 
 	return nil


### PR DESCRIPTION
- All file operation errors now include the file path in quotes
- Parse errors include both file path and format type
- Regex errors include both pattern and file path
- Extension errors include source/destination paths