### PR TITLE
refactor(core): centralize file permission and timeout constants

### DIFF
--- a/cmd/sley/initcmd/initcmd.go
+++ b/cmd/sley/initcmd/initcmd.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"strings"
 
+	"github.com/indaco/sley/internal/config"
 	"github.com/indaco/sley/internal/printer"
 	"github.com/indaco/sley/internal/semver"
 	"github.com/urfave/cli/v3"
@@ -127,7 +128,7 @@ func initializeVersionFileWithMigration(path string, migratedVersion string) (bo
 
 	// Use migrated version if provided, otherwise use default initialization
 	if migratedVersion != "" {
-		if err := os.WriteFile(path, []byte(migratedVersion+"\n"), 0600); err != nil {
+		if err := os.WriteFile(path, []byte(migratedVersion+"\n"), semver.VersionFilePerm); err != nil {
 			return false, fmt.Errorf("failed to write version file: %w", err)
 		}
 		return true, nil
@@ -268,7 +269,7 @@ func createConfigFile(selectedPlugins []string, forceFlag bool) (bool, error) {
 	}
 
 	// Write config file
-	if err := os.WriteFile(configPath, configData, 0600); err != nil {
+	if err := os.WriteFile(configPath, configData, config.ConfigFilePerm); err != nil {
 		return false, fmt.Errorf("failed to write config file: %w", err)
 	}
 

--- a/cmd/sley/initcmd/workspace.go
+++ b/cmd/sley/initcmd/workspace.go
@@ -136,7 +136,7 @@ func createWorkspaceConfigFile(plugins []string, modules []DiscoveredModule, for
 		return false, fmt.Errorf("failed to generate config: %w", err)
 	}
 
-	if err := os.WriteFile(configPath, configData, 0600); err != nil {
+	if err := os.WriteFile(configPath, configData, config.ConfigFilePerm); err != nil {
 		return false, fmt.Errorf("failed to write config file: %w", err)
 	}
 

--- a/internal/cmdrunner/runner.go
+++ b/internal/cmdrunner/runner.go
@@ -4,15 +4,16 @@ import (
 	"context"
 	"os"
 	"os/exec"
-	"time"
 
 	"github.com/indaco/sley/internal/apperrors"
+	"github.com/indaco/sley/internal/core"
 )
 
 // Default timeouts for command execution.
+// These reference the centralized timeout constants in core package.
 const (
-	DefaultTimeout       = 30 * time.Second
-	DefaultOutputTimeout = 5 * time.Second
+	DefaultTimeout       = core.TimeoutDefault
+	DefaultOutputTimeout = core.TimeoutShort
 )
 
 // RunCommandContext executes a command with the given context.

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -7,6 +7,7 @@ import (
 	"path/filepath"
 
 	"github.com/goccy/go-yaml"
+	"github.com/indaco/sley/internal/core"
 )
 
 // ExtensionConfig holds configuration for external extensions.
@@ -84,7 +85,8 @@ func NormalizeVersionPath(path string) string {
 }
 
 // ConfigFilePerm defines secure file permissions for config files (owner read/write only).
-const ConfigFilePerm = 0600
+// References core.PermOwnerRW for consistency across the codebase.
+const ConfigFilePerm = core.PermOwnerRW
 
 func saveConfig(cfg *Config) error {
 	const configFile = ".sley.yaml"

--- a/internal/core/constants.go
+++ b/internal/core/constants.go
@@ -1,0 +1,52 @@
+package core
+
+import (
+	"io/fs"
+	"time"
+)
+
+// File permission constants for consistent security across the codebase.
+// These follow the principle of least privilege.
+const (
+	// PermOwnerRW is read/write for owner only (0600).
+	// Use for sensitive files: config, version files, audit logs.
+	PermOwnerRW fs.FileMode = 0600
+
+	// PermOwnerRWGroupR is read/write for owner, read for group (0640).
+	// Use for files that need to be readable by group members.
+	PermOwnerRWGroupR fs.FileMode = 0640
+
+	// PermPublicRead is read/write for owner, read for all (0644).
+	// Use for public files: changelogs, documentation.
+	PermPublicRead fs.FileMode = 0644
+
+	// PermDirDefault is read/write/execute for owner, read/execute for others (0755).
+	// Use for directories that need to be traversable.
+	PermDirDefault fs.FileMode = 0755
+
+	// PermDirPrivate is read/write/execute for owner only (0700).
+	// Use for directories containing sensitive data.
+	PermDirPrivate fs.FileMode = 0700
+
+	// PermExecutable is the executable bit mask (0111).
+	// Use to check if a file has any executable permission.
+	PermExecutable fs.FileMode = 0111
+)
+
+// Timeout constants for external operations.
+const (
+	// TimeoutDefault is the default timeout for external commands (30 seconds).
+	TimeoutDefault = 30 * time.Second
+
+	// TimeoutShort is a shorter timeout for quick operations (5 seconds).
+	TimeoutShort = 5 * time.Second
+
+	// TimeoutLong is a longer timeout for potentially slow operations (2 minutes).
+	TimeoutLong = 2 * time.Minute
+)
+
+// Discovery constants for workspace module discovery.
+const (
+	// MaxDiscoveryDepth is the default maximum directory depth for module discovery.
+	MaxDiscoveryDepth = 10
+)

--- a/internal/extensionmgr/executor.go
+++ b/internal/extensionmgr/executor.go
@@ -10,6 +10,7 @@ import (
 	"path/filepath"
 	"time"
 
+	"github.com/indaco/sley/internal/core"
 	"github.com/indaco/sley/internal/pathutil"
 )
 
@@ -43,8 +44,9 @@ type ScriptExecutor struct {
 	Timeout time.Duration
 }
 
-// DefaultTimeout is the default execution timeout for extension scripts
-const DefaultTimeout = 30 * time.Second
+// DefaultTimeout is the default execution timeout for extension scripts.
+// Uses core.TimeoutDefault for consistency across the codebase.
+const DefaultTimeout = core.TimeoutDefault
 
 // MaxOutputSize limits the amount of data read from script stdout/stderr
 const MaxOutputSize = 1024 * 1024 // 1MB
@@ -85,7 +87,7 @@ func (e *ScriptExecutor) Execute(ctx context.Context, scriptPath string, input H
 	}
 
 	// Check if file is executable (Unix-like systems)
-	if info.Mode()&0111 == 0 {
+	if info.Mode()&core.PermExecutable == 0 {
 		return nil, fmt.Errorf("script is not executable: %s", absPath)
 	}
 

--- a/internal/extensionmgr/updater.go
+++ b/internal/extensionmgr/updater.go
@@ -39,5 +39,5 @@ func AddExtensionToConfig(path string, extension config.ExtensionConfig) error {
 		return err
 	}
 
-	return os.WriteFile(path, out, 0644)
+	return os.WriteFile(path, out, config.ConfigFilePerm)
 }

--- a/internal/plugins/auditlog/auditlog.go
+++ b/internal/plugins/auditlog/auditlog.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/goccy/go-yaml"
+	"github.com/indaco/sley/internal/core"
 )
 
 // AuditLog defines the interface for audit logging.
@@ -216,7 +217,7 @@ func (p *AuditLogPlugin) writeLogFile(logFile *AuditLogFile) error {
 	}
 
 	path := p.config.GetPath()
-	if err := p.fileOps.WriteFile(path, data, 0644); err != nil {
+	if err := p.fileOps.WriteFile(path, data, core.PermPublicRead); err != nil {
 		return fmt.Errorf("failed to write audit log %q: %w", path, err)
 	}
 

--- a/internal/semver/file.go
+++ b/internal/semver/file.go
@@ -1,9 +1,14 @@
 package semver
 
-import "context"
+import (
+	"context"
+
+	"github.com/indaco/sley/internal/core"
+)
 
 // VersionFilePerm defines secure file permissions for version files (owner read/write only).
-const VersionFilePerm = 0600
+// References core.PermOwnerRW for consistency across the codebase.
+const VersionFilePerm = core.PermOwnerRW
 
 // ReadVersion reads a version string from the given file and parses it into a SemVersion.
 // This is a convenience function that uses the default VersionManager with context.Background().

--- a/internal/semver/manager.go
+++ b/internal/semver/manager.go
@@ -45,7 +45,7 @@ func (m *VersionManager) Read(ctx context.Context, path string) (SemVersion, err
 // Save writes a version to the given path.
 func (m *VersionManager) Save(ctx context.Context, path string, version SemVersion) error {
 	// Ensure parent directory exists
-	if err := m.fs.MkdirAll(ctx, filepath.Dir(path), 0755); err != nil {
+	if err := m.fs.MkdirAll(ctx, filepath.Dir(path), core.PermDirDefault); err != nil {
 		return err
 	}
 	return m.fs.WriteFile(ctx, path, []byte(version.String()+"\n"), VersionFilePerm)


### PR DESCRIPTION
## Summary

- Create core/constants.go with file permissions and timeouts
- Update ConfigFilePerm and VersionFilePerm to reference core
- Replace magic numbers in production code with named constants