### PR TITLE
refactor(apperrors): standardize error handling patterns

### DIFF
--- a/internal/apperrors/errors.go
+++ b/internal/apperrors/errors.go
@@ -1,9 +1,46 @@
 // Package apperrors defines custom error types for the sley application.
 // These typed errors enable proper error handling with errors.Is and errors.As
 // without coupling internal packages to the CLI framework.
+//
+// Error Handling Conventions:
+//   - Always wrap errors from external packages with context
+//   - Use sentinel errors for common, well-known conditions
+//   - Use typed errors when callers need to extract structured information
+//   - Include relevant context (file paths, values) in error messages
 package apperrors
 
-import "fmt"
+import (
+	"errors"
+	"fmt"
+)
+
+// Sentinel errors for common conditions.
+// Use errors.Is() to check for these conditions.
+var (
+	// ErrNotFound indicates a resource was not found.
+	ErrNotFound = errors.New("not found")
+
+	// ErrInvalidInput indicates invalid user input.
+	ErrInvalidInput = errors.New("invalid input")
+
+	// ErrPermissionDenied indicates insufficient permissions.
+	ErrPermissionDenied = errors.New("permission denied")
+
+	// ErrAlreadyExists indicates a resource already exists.
+	ErrAlreadyExists = errors.New("already exists")
+
+	// ErrTimeout indicates an operation timed out.
+	ErrTimeout = errors.New("operation timed out")
+
+	// ErrCanceled indicates an operation was canceled.
+	ErrCanceled = errors.New("operation canceled")
+
+	// ErrGitOperation indicates a git operation failed.
+	ErrGitOperation = errors.New("git operation failed")
+
+	// ErrExtension indicates an extension-related error.
+	ErrExtension = errors.New("extension error")
+)
 
 // VersionFileNotFoundError indicates that the version file does not exist.
 type VersionFileNotFoundError struct {
@@ -90,4 +127,85 @@ func (e *HookError) Error() string {
 
 func (e *HookError) Unwrap() error {
 	return e.Err
+}
+
+// GitError indicates a git operation error with command context.
+type GitError struct {
+	Operation string
+	Err       error
+}
+
+func (e *GitError) Error() string {
+	return fmt.Sprintf("git %s failed: %v", e.Operation, e.Err)
+}
+
+func (e *GitError) Unwrap() error {
+	return e.Err
+}
+
+// Is allows errors.Is to match against ErrGitOperation.
+func (e *GitError) Is(target error) bool {
+	return target == ErrGitOperation
+}
+
+// FileError indicates a file operation error with path context.
+type FileError struct {
+	Op   string
+	Path string
+	Err  error
+}
+
+func (e *FileError) Error() string {
+	return fmt.Sprintf("%s %q: %v", e.Op, e.Path, e.Err)
+}
+
+func (e *FileError) Unwrap() error {
+	return e.Err
+}
+
+// ExtensionError indicates an extension-related error.
+type ExtensionError struct {
+	Name string
+	Op   string
+	Err  error
+}
+
+func (e *ExtensionError) Error() string {
+	if e.Name != "" {
+		return fmt.Sprintf("extension %q %s: %v", e.Name, e.Op, e.Err)
+	}
+	return fmt.Sprintf("extension %s: %v", e.Op, e.Err)
+}
+
+func (e *ExtensionError) Unwrap() error {
+	return e.Err
+}
+
+// Is allows errors.Is to match against ErrExtension.
+func (e *ExtensionError) Is(target error) bool {
+	return target == ErrExtension
+}
+
+// WrapGit wraps an error as a git operation error.
+func WrapGit(operation string, err error) error {
+	if err == nil {
+		return nil
+	}
+	return &GitError{Operation: operation, Err: err}
+}
+
+// WrapFile wraps an error as a file operation error.
+func WrapFile(op, path string, err error) error {
+	if err == nil {
+		return nil
+	}
+	return &FileError{Op: op, Path: path, Err: err}
+}
+
+// WrapExtension wraps an error as an extension error.
+func WrapExtension(name, op string, err error) error {
+	if err == nil {
+		return nil
+	}
+	return &ExtensionError{Name: name, Op: op, Err: err}
 }

--- a/internal/extensionmgr/copy.go
+++ b/internal/extensionmgr/copy.go
@@ -1,6 +1,7 @@
 package extensionmgr
 
 import (
+	"fmt"
 	"io"
 	"os"
 	"path/filepath"
@@ -37,7 +38,7 @@ var (
 func copyDir(src, dst string) error {
 	return walkFn(src, func(path string, info os.FileInfo, err error) error {
 		if err != nil {
-			return err
+			return fmt.Errorf("walk error at %q: %w", path, err)
 		}
 
 		skipFile, skipDir := shouldSkipEntry(info)
@@ -50,7 +51,7 @@ func copyDir(src, dst string) error {
 
 		rel, err := relFn(src, path)
 		if err != nil {
-			return err
+			return fmt.Errorf("failed to compute relative path from %q to %q: %w", src, path, err)
 		}
 
 		target := filepath.Join(dst, rel)
@@ -68,18 +69,18 @@ func copyDir(src, dst string) error {
 func copyFile(src, dst string, perm os.FileMode) error {
 	in, err := openSrcFile(src)
 	if err != nil {
-		return err
+		return fmt.Errorf("failed to open source %q: %w", src, err)
 	}
 	defer in.Close()
 
 	out, err := openDstFile(dst, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, perm)
 	if err != nil {
-		return err
+		return fmt.Errorf("failed to create destination %q: %w", dst, err)
 	}
 	defer out.Close()
 
 	if _, err := copyFn(out, in); err != nil {
-		return err
+		return fmt.Errorf("failed to copy %q to %q: %w", src, dst, err)
 	}
 
 	return nil

--- a/internal/extensionmgr/updater.go
+++ b/internal/extensionmgr/updater.go
@@ -1,6 +1,7 @@
 package extensionmgr
 
 import (
+	"fmt"
 	"os"
 
 	"github.com/goccy/go-yaml"
@@ -17,12 +18,12 @@ var (
 func AddExtensionToConfig(path string, extension config.ExtensionConfig) error {
 	data, err := os.ReadFile(path)
 	if err != nil {
-		return err
+		return fmt.Errorf("failed to read config %q: %w", path, err)
 	}
 
 	var cfg config.Config
 	if err := yaml.Unmarshal(data, &cfg); err != nil {
-		return err
+		return fmt.Errorf("failed to parse config %q: %w", path, err)
 	}
 
 	// Avoid duplicates
@@ -36,8 +37,11 @@ func AddExtensionToConfig(path string, extension config.ExtensionConfig) error {
 
 	out, err := marshalFunc(cfg)
 	if err != nil {
-		return err
+		return fmt.Errorf("failed to marshal config: %w", err)
 	}
 
-	return os.WriteFile(path, out, config.ConfigFilePerm)
+	if err := os.WriteFile(path, out, config.ConfigFilePerm); err != nil {
+		return fmt.Errorf("failed to write config %q: %w", path, err)
+	}
+	return nil
 }

--- a/internal/extensionmgr/updater_test.go
+++ b/internal/extensionmgr/updater_test.go
@@ -119,7 +119,7 @@ func TestAddExtensionToConfig_ReadFileError(t *testing.T) {
 	}
 
 	err := AddExtensionToConfig(invalidPath, extension)
-	if err == nil || !os.IsNotExist(err) {
+	if err == nil || !errors.Is(err, os.ErrNotExist) {
 		t.Fatalf("expected file not found error, got: %v", err)
 	}
 }

--- a/internal/extensionmgr/urlinstaller.go
+++ b/internal/extensionmgr/urlinstaller.go
@@ -115,7 +115,7 @@ func InstallFromURL(urlStr, configPath, extensionDirectory string) error {
 	fmt.Printf("Cloning %s...\n", repoURL.String())
 	tempDir, err := CloneRepository(repoURL)
 	if err != nil {
-		return err
+		return fmt.Errorf("failed to clone repository %s: %w", repoURL.String(), err)
 	}
 
 	// Clean up temp directory after installation

--- a/internal/plugins/tagmanager/git.go
+++ b/internal/plugins/tagmanager/git.go
@@ -28,7 +28,7 @@ func createAnnotatedTag(name, message string) error {
 		if stderrMsg != "" {
 			return fmt.Errorf("%s: %w", stderrMsg, err)
 		}
-		return err
+		return fmt.Errorf("git tag (annotated) failed: %w", err)
 	}
 	return nil
 }
@@ -44,7 +44,7 @@ func createLightweightTag(name string) error {
 		if stderrMsg != "" {
 			return fmt.Errorf("%s: %w", stderrMsg, err)
 		}
-		return err
+		return fmt.Errorf("git tag (lightweight) failed: %w", err)
 	}
 	return nil
 }
@@ -98,7 +98,7 @@ func pushTag(name string) error {
 		if stderrMsg != "" {
 			return fmt.Errorf("%s: %w", stderrMsg, err)
 		}
-		return err
+		return fmt.Errorf("git push tag failed: %w", err)
 	}
 	return nil
 }
@@ -120,7 +120,7 @@ func ListTags(pattern string) ([]string, error) {
 		if stderrMsg != "" {
 			return nil, fmt.Errorf("%s: %w", stderrMsg, err)
 		}
-		return nil, err
+		return nil, fmt.Errorf("git tag list failed: %w", err)
 	}
 
 	output := strings.TrimSpace(stdout.String())
@@ -142,7 +142,7 @@ func DeleteTag(name string) error {
 		if stderrMsg != "" {
 			return fmt.Errorf("%s: %w", stderrMsg, err)
 		}
-		return err
+		return fmt.Errorf("git tag delete failed: %w", err)
 	}
 	return nil
 }


### PR DESCRIPTION
## Summary


- Add sentinel errors to `apperrors` package for common conditions (`ErrNotFound`, `ErrGitOperation`, `ErrTimeout`, etc.)
- Add typed errors (`GitError`, `FileError`, `ExtensionError`) with proper `Unwrap()` and `Is()` methods
- Add helper functions (`WrapGit`, `WrapFile`, `WrapExtension`) for consistent error wrapping
- Wrap raw error returns in `tagmanager` and `extensionmgr` packages with descriptive context