### PR TITLE
fix(semver): add input length validation to prevent ReDoS attacks

### DIFF
--- a/internal/semver/semver_test.go
+++ b/internal/semver/semver_test.go
@@ -195,6 +195,18 @@ func TestParseVersion_ErrorCases(t *testing.T) {
 			t.Errorf("expected ErrInvalidVersion, got %v", err)
 		}
 	})
+
+	t.Run("version string too long (ReDoS prevention)", func(t *testing.T) {
+		// Create a version string that exceeds maxVersionLength
+		longVersion := "1.0.0-" + strings.Repeat("a", maxVersionLength)
+		_, err := ParseVersion(longVersion)
+		if err == nil || !errors.Is(err, errInvalidVersion) {
+			t.Errorf("expected ErrInvalidVersion for too-long version, got %v", err)
+		}
+		if err != nil && !strings.Contains(err.Error(), "exceeds maximum length") {
+			t.Errorf("expected error message about maximum length, got %v", err)
+		}
+	})
 }
 
 func TestParseVersion_InvalidFormat(t *testing.T) {

--- a/internal/semver/version.go
+++ b/internal/semver/version.go
@@ -57,10 +57,19 @@ func (v SemVersion) String() string {
 	return s
 }
 
+// maxVersionLength is the maximum allowed length for a version string.
+// This prevents potential ReDoS attacks on the regex parser.
+const maxVersionLength = 128
+
 // ParseVersion parses a semantic version string and returns a SemVersion.
-// Returns an error if the version format is invalid.
+// Returns an error if the version format is invalid or exceeds maxVersionLength.
 func ParseVersion(s string) (SemVersion, error) {
-	matches := versionRegex.FindStringSubmatch(strings.TrimSpace(s))
+	trimmed := strings.TrimSpace(s)
+	if len(trimmed) > maxVersionLength {
+		return SemVersion{}, fmt.Errorf("%w: version string exceeds maximum length of %d", errInvalidVersion, maxVersionLength)
+	}
+
+	matches := versionRegex.FindStringSubmatch(trimmed)
 	if len(matches) < 4 {
 		return SemVersion{}, errInvalidVersion
 	}


### PR DESCRIPTION
Limit version string input to 128 characters before regex parsing to prevent potential Regular Expression Denial of Service attacks.