### PR TITLE
feat(changelog): add merge-after config and improve CLI feedback

### DIFF
--- a/README.md
+++ b/README.md
@@ -492,6 +492,25 @@ sley validate
 # => Error: invalid version format: ...
 ```
 
+**Manage changelogs**
+
+While sley isn't a standalone changelog tool, the `changelog-generator` plugin provides full changelog support. This utility command helps you work with versioned changelog files created by the plugin.
+
+> [!NOTE]
+> Requires the `changelog-generator` plugin. See [docs/plugins/CHANGELOG_GENERATOR.md](docs/plugins/CHANGELOG_GENERATOR.md) for configuration options including automatic merging with `merge-after`.
+
+Merge versioned changelog files into a unified `CHANGELOG.md`:
+
+```bash
+sley changelog merge
+
+# Specify custom paths
+sley changelog merge --changes-dir .changes --output CHANGELOG.md
+
+# Use a custom header template
+sley changelog merge --header-template .changes/header.md
+```
+
 **Rolling back a version change**
 
 If you need to undo a version bump:

--- a/docs/plugins/examples/changelog-generator.yaml
+++ b/docs/plugins/examples/changelog-generator.yaml
@@ -10,6 +10,11 @@ plugins:
     format: "grouped" # "grouped", "keepachangelog", "github", or "minimal"
     changes-dir: ".changes"
     changelog-path: "CHANGELOG.md"
+    # merge-after controls when versioned changelog files are merged into CHANGELOG.md
+    # - "manual" (default): No auto-merge, use 'sley changelog merge' command
+    # - "immediate": Merge right after changelog generation
+    # - "prompt": Interactive confirmation (auto-skips in CI/non-interactive environments)
+    merge-after: "manual"
     repository:
       auto-detect: true
     use-default-icons: true

--- a/internal/config/config_plugins.go
+++ b/internal/config/config_plugins.go
@@ -202,6 +202,13 @@ type ChangelogGeneratorConfig struct {
 
 	// Contributors configures the contributors section.
 	Contributors *ContributorsConfig `yaml:"contributors,omitempty"`
+
+	// MergeAfter controls when versioned changelog files are merged into the unified changelog.
+	// Values:
+	// - "immediate" (merge right after generation)
+	// - "manual" (no auto-merge, default)
+	// - "prompt" (interactive confirmation, auto-skips in CI/non-interactive environments).
+	MergeAfter string `yaml:"merge-after,omitempty"`
 }
 
 // GetChangesDir returns the changes directory with default ".changes".
@@ -234,6 +241,14 @@ func (c *ChangelogGeneratorConfig) GetFormat() string {
 		return "grouped"
 	}
 	return c.Format
+}
+
+// GetMergeAfter returns the merge-after setting with default "manual".
+func (c *ChangelogGeneratorConfig) GetMergeAfter() string {
+	if c.MergeAfter == "" {
+		return "manual"
+	}
+	return c.MergeAfter
 }
 
 // RepositoryConfig holds git repository settings for changelog links.

--- a/internal/config/validator_plugins.go
+++ b/internal/config/validator_plugins.go
@@ -267,10 +267,24 @@ func (v *Validator) validateChangelogGeneratorConfig() {
 	validFormats := map[string]bool{
 		"grouped":        true,
 		"keepachangelog": true,
+		"github":         true,
+		"minimal":        true,
 	}
 	if !validFormats[format] {
 		v.addValidation("Plugin: changelog-generator", false,
-			fmt.Sprintf("Invalid format '%s': must be 'grouped' or 'keepachangelog'", format), false)
+			fmt.Sprintf("Invalid format '%s': must be 'grouped', 'keepachangelog', 'github', or 'minimal'", format), false)
+	}
+
+	// Validate merge-after
+	mergeAfter := cfg.GetMergeAfter()
+	validMergeAfter := map[string]bool{
+		"immediate": true,
+		"manual":    true,
+		"prompt":    true,
+	}
+	if !validMergeAfter[mergeAfter] {
+		v.addValidation("Plugin: changelog-generator", false,
+			fmt.Sprintf("Invalid merge-after '%s': must be 'immediate', 'manual', or 'prompt'", mergeAfter), false)
 	}
 
 	// Validate repository config

--- a/internal/plugins/changeloggenerator/config.go
+++ b/internal/plugins/changeloggenerator/config.go
@@ -76,6 +76,11 @@ type Config struct {
 
 	// Contributors configures the contributors section.
 	Contributors *ContributorsConfig
+
+	// MergeAfter controls when versioned changelog files are merged into the unified changelog.
+	// Values: "immediate" (merge right after generation), "manual" (no auto-merge, default),
+	// "prompt" (interactive confirmation, auto-skips in CI/non-interactive environments).
+	MergeAfter string
 }
 
 // RepositoryConfig holds git repository settings for changelog links.
@@ -119,6 +124,7 @@ func DefaultConfig() *Config {
 		Format:        "grouped",
 		ChangesDir:    ".changes",
 		ChangelogPath: "CHANGELOG.md",
+		MergeAfter:    "manual",
 		Repository: &RepositoryConfig{
 			AutoDetect: true,
 		},
@@ -171,6 +177,7 @@ func FromConfigStruct(cfg *config.ChangelogGeneratorConfig) *Config {
 		Format:                 cfg.GetFormat(),
 		ChangesDir:             cfg.GetChangesDir(),
 		ChangelogPath:          cfg.GetChangelogPath(),
+		MergeAfter:             cfg.GetMergeAfter(),
 		HeaderTemplate:         cfg.HeaderTemplate,
 		ExcludePatterns:        cfg.ExcludePatterns,
 		IncludeNonConventional: cfg.IncludeNonConventional,

--- a/internal/plugins/changeloggenerator/config_test.go
+++ b/internal/plugins/changeloggenerator/config_test.go
@@ -21,6 +21,9 @@ func TestDefaultConfig(t *testing.T) {
 	if cfg.ChangelogPath != "CHANGELOG.md" {
 		t.Errorf("ChangelogPath = %q, want 'CHANGELOG.md'", cfg.ChangelogPath)
 	}
+	if cfg.MergeAfter != "manual" {
+		t.Errorf("MergeAfter = %q, want 'manual'", cfg.MergeAfter)
+	}
 	if cfg.Repository == nil {
 		t.Fatal("expected Repository to be non-nil")
 	}
@@ -187,6 +190,11 @@ func TestFromConfigStruct_Defaults(t *testing.T) {
 	// Should use default changes dir
 	if cfg.ChangesDir != ".changes" {
 		t.Errorf("ChangesDir = %q, want '.changes' (default)", cfg.ChangesDir)
+	}
+
+	// Should use default merge-after
+	if cfg.MergeAfter != "manual" {
+		t.Errorf("MergeAfter = %q, want 'manual' (default)", cfg.MergeAfter)
 	}
 
 	// Should have default groups
@@ -544,6 +552,55 @@ func TestFromConfigStruct_BreakingChangesIcon(t *testing.T) {
 			cfg := FromConfigStruct(tt.input)
 			if cfg.BreakingChangesIcon != tt.wantIcon {
 				t.Errorf("BreakingChangesIcon = %q, want %q", cfg.BreakingChangesIcon, tt.wantIcon)
+			}
+		})
+	}
+}
+
+func TestFromConfigStruct_MergeAfter(t *testing.T) {
+	tests := []struct {
+		name           string
+		input          *config.ChangelogGeneratorConfig
+		wantMergeAfter string
+	}{
+		{
+			name: "default when not specified",
+			input: &config.ChangelogGeneratorConfig{
+				Enabled: true,
+			},
+			wantMergeAfter: "manual",
+		},
+		{
+			name: "immediate value",
+			input: &config.ChangelogGeneratorConfig{
+				Enabled:    true,
+				MergeAfter: "immediate",
+			},
+			wantMergeAfter: "immediate",
+		},
+		{
+			name: "manual value",
+			input: &config.ChangelogGeneratorConfig{
+				Enabled:    true,
+				MergeAfter: "manual",
+			},
+			wantMergeAfter: "manual",
+		},
+		{
+			name: "prompt value",
+			input: &config.ChangelogGeneratorConfig{
+				Enabled:    true,
+				MergeAfter: "prompt",
+			},
+			wantMergeAfter: "prompt",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := FromConfigStruct(tt.input)
+			if cfg.MergeAfter != tt.wantMergeAfter {
+				t.Errorf("MergeAfter = %q, want %q", cfg.MergeAfter, tt.wantMergeAfter)
 			}
 		})
 	}


### PR DESCRIPTION
## Summary

- Add `merge-after` configuration option for the `changelog-generator` plugin to control automatic merging of versioned changelog files
- Improve `sley changelog merge` CLI feedback when the plugin is not enabled

Closes #130 

## Changes

### New `merge-after` config option

Controls when **versioned** changelog files are merged into `CHANGELOG.md`:

- `manual` (default): No auto-merge, use `sley changelog merge` command
- `immediate`: Merge right after changelog generation
- `prompt`: Interactive confirmation (auto-skips in CI/non-interactive environments)

### CLI improvements

- Warn user when running `changelog merge` without the `changelog-generator` plugin enabled
- Warn when `merge-after` is already set to something other than `manual`