### PR TITLE
fix(bumpcmd): add missing tag creation for bump auto command

### DIFF
--- a/cmd/sley/bumpcmd/auto.go
+++ b/cmd/sley/bumpcmd/auto.go
@@ -177,7 +177,9 @@ func runSingleModuleAuto(cmd *cli.Command, registry *plugins.PluginRegistry, pat
 	}
 
 	printer.PrintSuccess(fmt.Sprintf("Bumped version from %s to %s", current.String(), next.String()))
-	return nil
+
+	// Create tag after successful bump
+	return createTagAfterBump(registry, next, "auto")
 }
 
 // getNextVersion determines the next semantic version based on the provided label,


### PR DESCRIPTION
The `bump auto` command was not creating git tags even when the **tag-manager** plugin was enabled.

Added `createTagAfterBump` call at the end of `runSingleModuleAuto` to match the behavior of other bump commands.

Fixes #133