### PR TITLE
fix(bumpcmd): add missing extension hooks to auto and release commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -398,6 +398,10 @@ sley bump minor --meta ci.123
 
 sley bump major --pre rc.1 --meta build.7
 # => 2.0.0-rc.1+build.7
+
+# Skip pre-release hooks and extensions during bump
+sley bump patch --skip-hooks
+# => 1.2.4 (no hooks executed)
 ```
 
 > [!NOTE]

--- a/internal/extensionmgr/hooks.go
+++ b/internal/extensionmgr/hooks.go
@@ -10,6 +10,7 @@ import (
 	"github.com/indaco/sley/internal/config"
 	"github.com/indaco/sley/internal/console"
 	"github.com/indaco/sley/internal/extensions"
+	"github.com/indaco/sley/internal/printer"
 )
 
 // HookType represents the different hook points available in the extension system
@@ -73,7 +74,7 @@ func (r *ExtensionHookRunner) RunHooks(ctx context.Context, hookType HookType, i
 		scriptPath := filepath.Join(extCfg.Path, manifest.Entry)
 
 		// Execute the hook
-		fmt.Printf("Running extension hook %q (%s)... ", extCfg.Name, hookType)
+		fmt.Printf("Running extension %s (%s)... ", printer.Info(extCfg.Name), printer.Faint(string(hookType)))
 
 		output, err := r.Executor.Execute(ctx, scriptPath, input)
 		if err != nil {
@@ -84,7 +85,7 @@ func (r *ExtensionHookRunner) RunHooks(ctx context.Context, hookType HookType, i
 		console.PrintSuccess("OK")
 
 		if output.Message != "" {
-			fmt.Printf("  %s\n", output.Message)
+			fmt.Printf("  %s\n", printer.Faint(output.Message))
 		}
 
 		hooksExecuted++

--- a/internal/plugins/changeloggenerator/plugin.go
+++ b/internal/plugins/changeloggenerator/plugin.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 
+	"github.com/indaco/sley/internal/printer"
 	"github.com/indaco/sley/internal/tui"
 )
 
@@ -102,11 +103,12 @@ func (p *ChangelogGeneratorPlugin) GenerateForVersion(version, previousVersion, 
 
 	// Print warning about skipped non-conventional commits
 	if len(result.SkippedNonConventional) > 0 {
-		fmt.Fprintf(os.Stderr, "\nWarning: %d non-conventional commit(s) skipped:\n", len(result.SkippedNonConventional))
+		fmt.Fprintln(os.Stderr)
+		printer.PrintWarning(fmt.Sprintf("Warning: %d non-conventional commit(s) skipped:", len(result.SkippedNonConventional)))
 		for _, c := range result.SkippedNonConventional {
-			fmt.Fprintf(os.Stderr, "  - %s: %s\n", c.ShortHash, c.Subject)
+			fmt.Fprintf(os.Stderr, "  - %s: %s\n", printer.Faint(c.ShortHash), c.Subject)
 		}
-		fmt.Fprintf(os.Stderr, "Tip: Use conventional commit format (type: description) or set 'include-non-conventional: true' in config.\n\n")
+		fmt.Fprintf(os.Stderr, "%s Use conventional commit format (type: description) or set 'include-non-conventional: true' in config.\n\n", printer.Info("Tip:"))
 	}
 
 	// Write based on mode


### PR DESCRIPTION
 ## Summary

- Add missing `runPreBumpExtensionHooks` and `runPostBumpExtensionHooks` calls to `bump auto` and `bump release` commands
- Add missing `createTagAfterBump` call to `bump release` command
- Add tests for `--skip-hooks` flag and extension hook execution

Fixes #137