### PR TITLE
ci(hooks): add pre-push hook for quality checks and tests

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -7,3 +7,9 @@ repos:
         entry: scripts/githooks/commit-msg
         language: system
         stages: [commit-msg]
+      - id: pre-push-checks
+        name: Run quality checks and tests
+        entry: scripts/githooks/pre-push
+        language: system
+        stages: [pre-push]
+        pass_filenames: false

--- a/scripts/devbox-init.sh
+++ b/scripts/devbox-init.sh
@@ -53,24 +53,25 @@ log_info 'Setting up Git hooks with prek...'
 # Ensure custom hooks are executable
 if [ -f scripts/githooks/commit-msg ]; then
   chmod +x scripts/githooks/commit-msg
-  log_success 'Custom hooks made executable'
-else
-  log_warning 'scripts/githooks/commit-msg not found'
 fi
+if [ -f scripts/githooks/pre-push ]; then
+  chmod +x scripts/githooks/pre-push
+fi
+log_success 'Custom hooks made executable'
 
 if git rev-parse --is-inside-work-tree >/dev/null 2>&1; then
   if command -v prek >/dev/null 2>&1; then
-    # Install prek hooks (workspace mode for monorepo)
-    if prek install -- --workspace; then
-      log_success 'prek hooks installed in workspace mode'
+    # Install prek hooks for commit-msg and pre-push stages
+    if prek install --hook-type commit-msg --hook-type pre-push; then
+      log_success 'prek hooks installed (commit-msg, pre-push)'
     else
       log_warning 'Failed to install prek hooks'
     fi
   else
-    log_warning 'prek not installed  -  run: pip install prek'
+    log_warning 'prek not installed - run: cargo install prek'
   fi
 else
-  log_warning 'not a git repository  -  skipping hooks installation'
+  log_warning 'not a git repository - skipping hooks installation'
 fi
 
 log_default ""

--- a/scripts/githooks/pre-push
+++ b/scripts/githooks/pre-push
@@ -1,0 +1,40 @@
+#!/bin/sh
+
+# pre-push hook - runs quality checks and tests before pushing
+# Supports both devbox and non-devbox environments
+
+# Define color codes
+RED='\x1b[31;1m'
+GREEN='\x1b[32m'
+YELLOW='\x1b[33m'
+DIM='\x1b[2m'
+RESET='\x1b[0m'
+
+# Determine the command prefix based on devbox availability
+if command -v devbox >/dev/null 2>&1; then
+    CMD_PREFIX="devbox run"
+    printf "${DIM}Using devbox environment${RESET}\n"
+else
+    CMD_PREFIX=""
+fi
+
+# Run quality checks
+printf "${YELLOW}Running quality checks...${RESET}\n"
+if $CMD_PREFIX just check; then
+    printf "${GREEN}Quality checks passed${RESET}\n"
+else
+    printf "${RED}Quality checks failed!${RESET}\n" >&2
+    exit 1
+fi
+
+# Run tests
+printf "${YELLOW}Running tests...${RESET}\n"
+if $CMD_PREFIX just test; then
+    printf "${GREEN}Tests passed${RESET}\n"
+else
+    printf "${RED}Tests failed!${RESET}\n" >&2
+    exit 1
+fi
+
+printf "${GREEN}All pre-push checks passed${RESET}\n"
+exit 0


### PR DESCRIPTION
## Summary

- Add pre-push git hook that runs `just check` and `just test` before pushing
- Hook auto-detects devbox and uses `devbox run` prefix when available
- Update prek configuration and `devbox-init.sh` to install the new hook