### PR TITLE
fix(plugins): respect auto-sync flag in dependency-check validation

### DIFF
--- a/cmd/sley/bumpcmd/helpers.go
+++ b/cmd/sley/bumpcmd/helpers.go
@@ -183,6 +183,11 @@ func validateDependencyConsistency(registry *plugins.PluginRegistry, version sem
 	}
 
 	if len(inconsistencies) > 0 {
+		// If auto-sync is enabled, skip the error - inconsistencies will be fixed after the bump
+		if plugin.GetConfig().AutoSync {
+			return nil
+		}
+
 		var details strings.Builder
 		details.WriteString("version inconsistencies detected:\n")
 		for _, inc := range inconsistencies {


### PR DESCRIPTION
## Description

The `validateDependencyConsistency()` function now checks the `AutoSync` configuration flag before returning an error. When `auto-sync` is enabled, inconsistencies are allowed since they will be fixed after the bump.

## Related Issue

Fixes #172 
