### PR TITLE
fix(bump): respect pre-bump extension changes in auto command

### DIFF
--- a/internal/commands/bump/helpers.go
+++ b/internal/commands/bump/helpers.go
@@ -264,7 +264,7 @@ func deriveDependencyName(path string) string {
 
 // generateChangelogAfterBump generates changelog entries if changelog generator is enabled.
 // Returns nil if changelog generator is not enabled.
-func generateChangelogAfterBump(registry *plugins.PluginRegistry, version, previousVersion semver.SemVersion, bumpType string) error {
+func generateChangelogAfterBump(registry *plugins.PluginRegistry, version, _ semver.SemVersion, bumpType string) error {
 	cg := registry.GetChangelogGenerator()
 	if cg == nil {
 		return nil


### PR DESCRIPTION
## Description

Fix `bump auto` command to respect changes made by pre-bump extension hooks to the `.version` file.

This is important when `commit-parser: false` - the extension sets the definitive version and no additional bump should be applied.

## Related Issue

Fixes #182 

## Notes for Reviewers

N/A
