### PR TITLE
docs: restore plugin configuration examples

### DIFF
--- a/docs/examples/full-config.yaml
+++ b/docs/examples/full-config.yaml
@@ -1,0 +1,111 @@
+# Full Plugin Configuration Example
+# All plugins working together
+# See: https://sley.indaco.dev/reference/sley-yaml.html
+
+path: .version
+
+plugins:
+  # Commit Parser (enabled by default)
+  commit-parser: true
+
+  # Release Gate
+  release-gate:
+    enabled: true
+    require-clean-worktree: true
+    blocked-on-wip-commits: true
+    require-ci-pass: false
+    allowed-branches:
+      - "main"
+      - "release/*"
+    blocked-branches:
+      - "experimental/*"
+
+  # Version Validator
+  version-validator:
+    enabled: true
+    rules:
+      - type: pre-release-format
+        pattern: "^(alpha|beta|rc)(\\.[0-9]+)?$"
+      - type: major-version-max
+        value: 10
+      - type: max-prerelease-iterations
+        value: 10
+      - type: require-even-minor
+        enabled: false
+      - type: branch-constraint
+        branch: "release/*"
+        allowed: ["patch"]
+      - type: branch-constraint
+        branch: "main"
+        allowed: ["minor", "patch"]
+
+  # Dependency Check
+  dependency-check:
+    enabled: true
+    auto-sync: true
+    files:
+      - path: package.json
+        field: version
+        format: json
+      - path: Chart.yaml
+        field: version
+        format: yaml
+      - path: pyproject.toml
+        field: tool.poetry.version
+        format: toml
+      - path: VERSION
+        format: raw
+      - path: src/version.go
+        format: regex
+        pattern: 'const Version = "(.*?)"'
+
+  # Changelog Parser
+  changelog-parser:
+    enabled: true
+    path: CHANGELOG.md
+    require-unreleased-section: true
+    infer-bump-type: true
+    priority: commits
+
+  # Changelog Generator
+  changelog-generator:
+    enabled: true
+    mode: "both"
+    format: "grouped"
+    changes-dir: ".changes"
+    changelog-path: "CHANGELOG.md"
+    merge-after: "manual"
+    repository:
+      auto-detect: true
+    use-default-icons: true
+    exclude-patterns:
+      - "^Merge"
+      - "^WIP"
+      - "^fixup!"
+      - "^squash!"
+    include-non-conventional: false
+    contributors:
+      enabled: true
+      show-new-contributors: true
+
+  # Tag Manager
+  tag-manager:
+    enabled: true
+    auto-create: true # Default is false; set to true for automatic tagging during bump
+    prefix: v
+    annotate: true
+    push: false
+    tag-prereleases: false # Set to true to also tag pre-releases
+    sign: false
+    signing-key: ""
+    message-template: "Release {version}"
+
+  # Audit Log
+  audit-log:
+    enabled: true
+    path: ".version-history.json"
+    format: "json"
+    include-author: true
+    include-timestamp: true
+    include-commit-sha: true
+    include-branch: true

--- a/docs/examples/plugins/audit-log.yaml
+++ b/docs/examples/plugins/audit-log.yaml
@@ -1,0 +1,14 @@
+# Audit Log Plugin Example
+# See: https://sley.indaco.dev/plugins/audit-log.html
+
+path: .version
+
+plugins:
+  audit-log:
+    enabled: true
+    path: ".version-history.json"
+    format: "json" # or "yaml"
+    include-author: true
+    include-timestamp: true
+    include-commit-sha: true
+    include-branch: true

--- a/docs/examples/plugins/changelog-generator.yaml
+++ b/docs/examples/plugins/changelog-generator.yaml
@@ -1,0 +1,47 @@
+# Changelog Generator Plugin Example
+# See: https://sley.indaco.dev/plugins/changelog-generator.html
+
+path: .version
+
+plugins:
+  changelog-generator:
+    enabled: true
+    mode: "versioned" # "versioned", "unified", or "both"
+    format: "grouped" # "grouped", "keepachangelog", "github", or "minimal"
+    changes-dir: ".changes"
+    changelog-path: "CHANGELOG.md"
+    # merge-after controls when versioned changelog files are merged into CHANGELOG.md
+    # - "manual" (default): No auto-merge, use 'sley changelog merge' command
+    # - "immediate": Merge right after changelog generation
+    # - "prompt": Interactive confirmation (auto-skips in CI/non-interactive environments)
+    merge-after: "manual"
+    # header-template: "path/to/header.tmpl" # Optional custom header template
+    repository:
+      auto-detect: true
+      # provider: "github" # or "gitlab"
+      # host: "github.com"
+      # owner: "your-org"
+      # repo: "your-repo"
+    # Custom commit grouping rules (optional)
+    # groups:
+    #   - pattern: "^feat"
+    #     label: "Features"
+    #     icon: "sparkles"
+    use-default-icons: true
+    # group-icons:
+    #   Features: "sparkles"
+    #   "Bug Fixes": "bug"
+    # breaking-changes-icon: "warning"
+    exclude-patterns:
+      - "^Merge"
+      - "^WIP"
+      - "^fixup!"
+      - "^squash!"
+    include-non-conventional: false
+    contributors:
+      enabled: true
+      # format: "{{.Name}}"
+      # icon: "heart"
+      show-new-contributors: true
+      # new-contributors-format: "{{.Name}}"
+      # new-contributors-icon: "tada"

--- a/docs/examples/plugins/changelog-parser.yaml
+++ b/docs/examples/plugins/changelog-parser.yaml
@@ -1,0 +1,48 @@
+# Changelog Parser Plugin Example
+# See: https://sley.indaco.dev/plugins/changelog-parser.html
+
+path: .version
+
+plugins:
+  changelog-parser:
+    enabled: true
+    path: "CHANGELOG.md"
+    format: "auto" # keepachangelog, grouped, github, minimal, auto
+    require-unreleased-section: true
+    infer-bump-type: true
+    priority: "changelog" # "changelog" or "commits"
+
+  # Commit parser as fallback when priority is "changelog"
+  commit-parser: true
+
+# ---
+# Format-specific examples:
+# ---
+
+# Keep a Changelog (default):
+# plugins:
+#   changelog-parser:
+#     enabled: true
+#     format: keepachangelog
+
+# Grouped format with custom section mapping:
+# plugins:
+#   changelog-parser:
+#     enabled: true
+#     format: grouped
+#     grouped-section-map:
+#       "New Features": "Added"
+#       "Bug Fixes": "Fixed"
+#       "Breaking": "Removed"
+
+# GitHub format (limited inference - see docs):
+# plugins:
+#   changelog-parser:
+#     enabled: true
+#     format: github
+
+# Minimal format:
+# plugins:
+#   changelog-parser:
+#     enabled: true
+#     format: minimal

--- a/docs/examples/plugins/commit-parser.yaml
+++ b/docs/examples/plugins/commit-parser.yaml
@@ -1,0 +1,31 @@
+# Commit Parser Plugin Example
+# See: https://sley.indaco.dev/plugins/commit-parser.html
+
+path: .version
+
+plugins:
+  # Enabled by default - configure only to disable
+  commit-parser: true
+
+  # To disable:
+  # commit-parser: false
+
+# ---
+# Integration with changelog-parser:
+# ---
+
+# Use commit-parser as primary (recommended for CI/CD):
+# plugins:
+#   commit-parser: true
+#   changelog-parser:
+#     enabled: true
+#     format: auto
+#     priority: "commits"  # commit-parser takes precedence
+
+# Use changelog-parser as primary, commit-parser as fallback:
+# plugins:
+#   commit-parser: true
+#   changelog-parser:
+#     enabled: true
+#     format: keepachangelog
+#     priority: "changelog"  # changelog-parser takes precedence

--- a/docs/examples/plugins/dependency-check.yaml
+++ b/docs/examples/plugins/dependency-check.yaml
@@ -1,0 +1,33 @@
+# Dependency Check Plugin Example
+# See: https://sley.indaco.dev/plugins/dependency-check.html
+
+path: .version
+
+plugins:
+  dependency-check:
+    enabled: true
+    auto-sync: true
+    files:
+      # JSON
+      - path: package.json
+        field: version
+        format: json
+
+      # YAML
+      - path: Chart.yaml
+        field: version
+        format: yaml
+
+      # TOML (nested field)
+      - path: pyproject.toml
+        field: tool.poetry.version
+        format: toml
+
+      # Raw (entire file is the version)
+      - path: VERSION
+        format: raw
+
+      # Regex (pattern with capturing group)
+      - path: src/version.go
+        format: regex
+        pattern: 'const Version = "(.*?)"'

--- a/docs/examples/plugins/release-gate.yaml
+++ b/docs/examples/plugins/release-gate.yaml
@@ -1,0 +1,18 @@
+# Release Gate Plugin Example
+# See: https://sley.indaco.dev/plugins/release-gate.html
+
+path: .version
+
+plugins:
+  release-gate:
+    enabled: true
+    require-clean-worktree: true
+    blocked-on-wip-commits: true
+    require-ci-pass: false
+    allowed-branches:
+      - "main"
+      - "release/*"
+      - "hotfix/*"
+    blocked-branches:
+      - "experimental/*"
+      - "wip/*"

--- a/docs/examples/plugins/tag-manager.yaml
+++ b/docs/examples/plugins/tag-manager.yaml
@@ -1,0 +1,26 @@
+# Tag Manager Plugin Example
+# See: https://sley.indaco.dev/plugins/tag-manager.html
+
+path: .version
+
+plugins:
+  tag-manager:
+    enabled: true
+    # Set to true for automatic tagging during bump
+    # Default is false - use `sley tag create` for manual workflow
+    auto-create: false
+    prefix: "v"
+    annotate: true
+    push: false
+    # Set to true to also create tags for pre-release versions
+    tag-prereleases: false
+
+    # GPG Signing (optional)
+    # Requires git to be configured with a GPG signing key
+    sign: false
+    signing-key: "" # Optional: specific GPG key ID (uses git default if empty)
+
+    # Custom Message Template (optional)
+    # Available placeholders: {version}, {tag}, {prefix}, {date},
+    #                         {major}, {minor}, {patch}, {prerelease}, {build}
+    message-template: "Release {version}"

--- a/docs/examples/plugins/version-validator.yaml
+++ b/docs/examples/plugins/version-validator.yaml
@@ -1,0 +1,53 @@
+# Version Validator Plugin Example
+# See: https://sley.indaco.dev/plugins/version-validator.html
+
+path: .version
+
+plugins:
+  version-validator:
+    enabled: true
+    rules:
+      # Pre-release format validation
+      - type: "pre-release-format"
+        pattern: "^(alpha|beta|rc)(\\.[0-9]+)?$"
+
+      # Version number limits
+      - type: "major-version-max"
+        value: 10
+
+      # - type: "minor-version-max"
+      #   value: 99
+
+      # - type: "patch-version-max"
+      #   value: 99
+
+      # Pre-release iteration limit (e.g., alpha.6 fails if max is 5)
+      - type: "max-prerelease-iterations"
+        value: 10
+
+      # Require pre-release for 0.x versions
+      # - type: "require-pre-release-for-0x"
+      #   enabled: true
+
+      # Even minor version policy (stable releases must have even minor)
+      - type: "require-even-minor"
+        enabled: false # Set to true to enforce
+
+      # Disallow specific bump types
+      # - type: "no-major-bump"
+      #   enabled: true
+
+      # - type: "no-minor-bump"
+      #   enabled: true
+
+      # - type: "no-patch-bump"
+      #   enabled: true
+
+      # Branch constraints
+      - type: "branch-constraint"
+        branch: "release/*"
+        allowed: ["patch"]
+
+      - type: "branch-constraint"
+        branch: "main"
+        allowed: ["minor", "patch"]


### PR DESCRIPTION
## Description

Restore the `docs/examples/` folder containing plugin configuration examples that were accidentally deleted when migrating documentation to the dedicated website. 

## Related Issue

Follow-up to #176 (docs migration)

## Notes for Reviewers

Files restored from commit 0dcf7127408b337e894d69ed977421ba8b6c37e1^ and updated to match current documentation.
