### PR TITLE
feat(pre): add multi-module support for pre and bump pre commands

### DIFF
--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -62,7 +62,7 @@ func New(cfg *config.Config, registry *plugins.PluginRegistry) *urfavecli.Comman
 			show.Run(cfg),
 			set.Run(cfg),
 			bump.Run(cfg, registry),
-			pre.Run(cfg),
+			pre.Run(cfg, registry),
 			doctor.Run(cfg),
 			tag.Run(cfg),
 			changelog.Run(cfg),

--- a/internal/commands/bump/pre.go
+++ b/internal/commands/bump/pre.go
@@ -4,9 +4,11 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/indaco/sley/internal/cliflags"
 	"github.com/indaco/sley/internal/clix"
 	"github.com/indaco/sley/internal/config"
 	"github.com/indaco/sley/internal/hooks"
+	"github.com/indaco/sley/internal/operations"
 	"github.com/indaco/sley/internal/plugins"
 	"github.com/indaco/sley/internal/semver"
 	"github.com/urfave/cli/v3"
@@ -14,21 +16,32 @@ import (
 
 // preCmd returns the "pre" subcommand for incrementing pre-release versions.
 func preCmd(cfg *config.Config, registry *plugins.PluginRegistry) *cli.Command {
+	flags := []cli.Flag{
+		&cli.StringFlag{
+			Name:    "label",
+			Aliases: []string{"l"},
+			Usage:   "Pre-release label (e.g., alpha, beta, rc). If omitted, increments existing pre-release",
+		},
+		&cli.StringFlag{
+			Name:  "meta",
+			Usage: "Optional build metadata",
+		},
+		&cli.BoolFlag{
+			Name:  "preserve-meta",
+			Usage: "Preserve existing build metadata when bumping",
+		},
+		&cli.BoolFlag{
+			Name:  "skip-hooks",
+			Usage: "Skip pre-release hooks",
+		},
+	}
+	flags = append(flags, cliflags.MultiModuleFlags()...)
+
 	return &cli.Command{
 		Name:      "pre",
 		Usage:     "Increment pre-release version (e.g., rc.1 -> rc.2)",
-		UsageText: "sley bump pre [--label name] [--meta data] [--preserve-meta] [--skip-hooks]",
-		Flags: []cli.Flag{
-			&cli.StringFlag{
-				Name:    "label",
-				Aliases: []string{"l"},
-				Usage:   "Pre-release label (e.g., alpha, beta, rc). If omitted, increments existing pre-release",
-			},
-			&cli.BoolFlag{
-				Name:  "skip-hooks",
-				Usage: "Skip pre-release hooks",
-			},
-		},
+		UsageText: "sley bump pre [--label name] [--meta data] [--preserve-meta] [--skip-hooks] [--all] [--module name]",
+		Flags:     flags,
 		Action: func(ctx context.Context, cmd *cli.Command) error {
 			return runBumpPre(ctx, cmd, cfg, registry)
 		},
@@ -51,11 +64,14 @@ func runBumpPre(ctx context.Context, cmd *cli.Command, cfg *config.Config, regis
 		return err
 	}
 
-	if !execCtx.IsSingleModule() {
-		return fmt.Errorf("pre-release bump not yet supported for multi-module mode")
+	// Handle single-module mode
+	if execCtx.IsSingleModule() {
+		return runSingleModulePreBump(ctx, cmd, cfg, registry, execCtx, label, meta, isPreserveMeta, isSkipHooks)
 	}
 
-	return runSingleModulePreBump(ctx, cmd, cfg, registry, execCtx, label, meta, isPreserveMeta, isSkipHooks)
+	// Handle multi-module mode
+	// For pre-release bump, the label is used as the pre-release identifier
+	return runMultiModuleBump(ctx, cmd, execCtx, registry, operations.BumpPre, label, meta, isPreserveMeta)
 }
 
 // runSingleModulePreBump handles pre-release bump for single-module mode.

--- a/internal/commands/initialize/initcmd_test.go
+++ b/internal/commands/initialize/initcmd_test.go
@@ -166,7 +166,7 @@ func TestCLI_Command_InitializeVersionFilePermissionErrors(t *testing.T) {
 			cfg := &config.Config{Path: protectedPath}
 			appCli := testutils.BuildCLIForTests(
 				cfg.Path,
-				[]*cli.Command{Run(), bump.Run(cfg, plugins.NewPluginRegistry()), pre.Run(cfg)},
+				[]*cli.Command{Run(), bump.Run(cfg, plugins.NewPluginRegistry()), pre.Run(cfg, plugins.NewPluginRegistry())},
 			)
 
 			err := appCli.Run(context.Background(), append(tt.command, "--path", protectedPath))

--- a/internal/commands/pre/precmd_test.go
+++ b/internal/commands/pre/precmd_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 
 	"github.com/indaco/sley/internal/config"
+	"github.com/indaco/sley/internal/plugins"
 	"github.com/indaco/sley/internal/semver"
 	"github.com/indaco/sley/internal/testutils"
 	"github.com/indaco/sley/internal/workspace"
@@ -22,7 +23,7 @@ func TestCLI_PreCommand_StaticLabel(t *testing.T) {
 
 	// Prepare and run the CLI command
 	cfg := &config.Config{Path: versionPath}
-	appCli := testutils.BuildCLIForTests(cfg.Path, []*cli.Command{Run(cfg)})
+	appCli := testutils.BuildCLIForTests(cfg.Path, []*cli.Command{Run(cfg, plugins.NewPluginRegistry())})
 
 	testutils.WriteTempVersionFile(t, tmpDir, "1.2.3")
 	testutils.RunCLITest(t, appCli, []string{"sley", "pre", "--label", "beta.1"}, tmpDir)
@@ -39,7 +40,7 @@ func TestCLI_PreCommand_Increment(t *testing.T) {
 
 	// Prepare and run the CLI command
 	cfg := &config.Config{Path: versionPath}
-	appCli := testutils.BuildCLIForTests(cfg.Path, []*cli.Command{Run(cfg)})
+	appCli := testutils.BuildCLIForTests(cfg.Path, []*cli.Command{Run(cfg, plugins.NewPluginRegistry())})
 
 	testutils.RunCLITest(t, appCli, []string{"sley", "pre", "--label", "beta", "--inc"}, tmpDir)
 	content := testutils.ReadTempVersionFile(t, tmpDir)
@@ -54,7 +55,7 @@ func TestCLI_PreCommand_AutoInitFeedback(t *testing.T) {
 
 	// Prepare and run the CLI command
 	cfg := &config.Config{Path: versionPath}
-	appCli := testutils.BuildCLIForTests(cfg.Path, []*cli.Command{Run(cfg)})
+	appCli := testutils.BuildCLIForTests(cfg.Path, []*cli.Command{Run(cfg, plugins.NewPluginRegistry())})
 
 	output, err := testutils.CaptureStdout(func() {
 		testutils.RunCLITest(t, appCli, []string{"sley", "pre", "--label", "alpha"}, tmpDir)
@@ -80,7 +81,7 @@ func TestCLI_PreCommand_InvalidVersion(t *testing.T) {
 
 	// Prepare and run the CLI command
 	cfg := &config.Config{Path: defaultPath}
-	appCli := testutils.BuildCLIForTests(cfg.Path, []*cli.Command{Run(cfg)})
+	appCli := testutils.BuildCLIForTests(cfg.Path, []*cli.Command{Run(cfg, plugins.NewPluginRegistry())})
 
 	err := appCli.Run(context.Background(), []string{
 		"sley", "pre", "--label", "alpha", "--path", customPath,
@@ -110,7 +111,7 @@ func TestCLI_PreCommand_SaveVersionFails(t *testing.T) {
 
 		// Prepare and run the CLI command
 		cfg := &config.Config{Path: versionPath}
-		appCli := testutils.BuildCLIForTests(cfg.Path, []*cli.Command{Run(cfg)})
+		appCli := testutils.BuildCLIForTests(cfg.Path, []*cli.Command{Run(cfg, plugins.NewPluginRegistry())})
 
 		err := appCli.Run(context.Background(), []string{
 			"sley", "pre", "--label", "rc", "--path", versionPath,
@@ -151,7 +152,7 @@ func TestCLI_PreCommand_StaticLabel_Variants(t *testing.T) {
 	versionPath := filepath.Join(tmpDir, ".version")
 
 	cfg := &config.Config{Path: versionPath}
-	appCli := testutils.BuildCLIForTests(cfg.Path, []*cli.Command{Run(cfg)})
+	appCli := testutils.BuildCLIForTests(cfg.Path, []*cli.Command{Run(cfg, plugins.NewPluginRegistry())})
 
 	tests := []struct {
 		name     string
@@ -183,7 +184,7 @@ func TestCLI_PreCommand_Increment_Variants(t *testing.T) {
 	versionPath := filepath.Join(tmpDir, ".version")
 
 	cfg := &config.Config{Path: versionPath}
-	appCli := testutils.BuildCLIForTests(cfg.Path, []*cli.Command{Run(cfg)})
+	appCli := testutils.BuildCLIForTests(cfg.Path, []*cli.Command{Run(cfg, plugins.NewPluginRegistry())})
 
 	tests := []struct {
 		name     string
@@ -216,7 +217,7 @@ func TestCLI_PreCommand_LabelSwitchWithIncrement(t *testing.T) {
 	versionPath := filepath.Join(tmpDir, ".version")
 
 	cfg := &config.Config{Path: versionPath}
-	appCli := testutils.BuildCLIForTests(cfg.Path, []*cli.Command{Run(cfg)})
+	appCli := testutils.BuildCLIForTests(cfg.Path, []*cli.Command{Run(cfg, plugins.NewPluginRegistry())})
 
 	tests := []struct {
 		name     string
@@ -246,7 +247,7 @@ func TestCLI_PreCommand_EdgeCases(t *testing.T) {
 	versionPath := filepath.Join(tmpDir, ".version")
 
 	cfg := &config.Config{Path: versionPath}
-	appCli := testutils.BuildCLIForTests(cfg.Path, []*cli.Command{Run(cfg)})
+	appCli := testutils.BuildCLIForTests(cfg.Path, []*cli.Command{Run(cfg, plugins.NewPluginRegistry())})
 
 	tests := []struct {
 		name     string
@@ -295,7 +296,7 @@ func TestCLI_PreCommand_PermissionErrors(t *testing.T) {
 	versionPath := filepath.Join(protectedDir, ".version")
 
 	cfg := &config.Config{Path: versionPath}
-	appCli := testutils.BuildCLIForTests(cfg.Path, []*cli.Command{Run(cfg)})
+	appCli := testutils.BuildCLIForTests(cfg.Path, []*cli.Command{Run(cfg, plugins.NewPluginRegistry())})
 
 	err := appCli.Run(context.Background(), []string{
 		"sley", "pre", "--label", "alpha", "--path", versionPath,
@@ -341,7 +342,7 @@ func TestCLI_PreCommand_MultiModule_All(t *testing.T) {
 		},
 	}
 
-	appCli := testutils.BuildCLIForTests(cfg.Path, []*cli.Command{Run(cfg)})
+	appCli := testutils.BuildCLIForTests(cfg.Path, []*cli.Command{Run(cfg, plugins.NewPluginRegistry())})
 
 	// Test with --all flag
 	output, err := testutils.CaptureStdout(func() {
@@ -401,7 +402,7 @@ func TestCLI_PreCommand_MultiModule_Increment(t *testing.T) {
 		},
 	}
 
-	appCli := testutils.BuildCLIForTests(cfg.Path, []*cli.Command{Run(cfg)})
+	appCli := testutils.BuildCLIForTests(cfg.Path, []*cli.Command{Run(cfg, plugins.NewPluginRegistry())})
 
 	// Test with --all and --inc flags
 	output, err := testutils.CaptureStdout(func() {
@@ -459,7 +460,7 @@ func TestCLI_PreCommand_MultiModule_Specific(t *testing.T) {
 		},
 	}
 
-	appCli := testutils.BuildCLIForTests(cfg.Path, []*cli.Command{Run(cfg)})
+	appCli := testutils.BuildCLIForTests(cfg.Path, []*cli.Command{Run(cfg, plugins.NewPluginRegistry())})
 
 	// Test with --module flag to target specific module
 	testutils.RunCLITest(t, appCli, []string{"sley", "pre", "--label", "alpha", "--module", "module-a"}, tmpDir)
@@ -507,7 +508,7 @@ func TestCLI_PreCommand_MultiModule_Quiet(t *testing.T) {
 		},
 	}
 
-	appCli := testutils.BuildCLIForTests(cfg.Path, []*cli.Command{Run(cfg)})
+	appCli := testutils.BuildCLIForTests(cfg.Path, []*cli.Command{Run(cfg, plugins.NewPluginRegistry())})
 
 	// Test with --quiet flag
 	output, err := testutils.CaptureStdout(func() {
@@ -562,7 +563,7 @@ func TestCLI_PreCommand_MultiModule_JSONFormat(t *testing.T) {
 		},
 	}
 
-	appCli := testutils.BuildCLIForTests(cfg.Path, []*cli.Command{Run(cfg)})
+	appCli := testutils.BuildCLIForTests(cfg.Path, []*cli.Command{Run(cfg, plugins.NewPluginRegistry())})
 
 	// Test with --format json
 	output, err := testutils.CaptureStdout(func() {
@@ -614,7 +615,7 @@ func TestCLI_PreCommand_MultiModule_Parallel(t *testing.T) {
 		},
 	}
 
-	appCli := testutils.BuildCLIForTests(cfg.Path, []*cli.Command{Run(cfg)})
+	appCli := testutils.BuildCLIForTests(cfg.Path, []*cli.Command{Run(cfg, plugins.NewPluginRegistry())})
 
 	// Test with --parallel flag
 	testutils.RunCLITest(t, appCli, []string{"sley", "pre", "--label", "alpha", "--all", "--parallel"}, tmpDir)
@@ -660,7 +661,7 @@ func TestCLI_PreCommand_MultiModule_TextFormat(t *testing.T) {
 		},
 	}
 
-	appCli := testutils.BuildCLIForTests(cfg.Path, []*cli.Command{Run(cfg)})
+	appCli := testutils.BuildCLIForTests(cfg.Path, []*cli.Command{Run(cfg, plugins.NewPluginRegistry())})
 
 	// Test with --format text
 	output, err := testutils.CaptureStdout(func() {


### PR DESCRIPTION
## Description

Add multi-module support to the standalone `sley pre` and `sley bump pre` commands:

- Support `--all` flag to set/increment pre-release on all modules
- Support `--module <name>` flag to target specific modules
- Consistent output formatting with other multi-module commands (`--format`, `--quiet`, `--parallel`)

**Example usage:**

```bash
# Set pre-release on all modules
sley pre --label rc --all

# Increment pre-release on specific module
sley pre --label beta --inc --module api
```

 ## Related Issue

  N/A

 ## Notes for Reviewers

- Follows the same patterns as `bump patch/minor/major --all` commands
- The `--non-interactive` flag is supported for CI/CD pipelines