### PR TITLE
feat(tui): add configurable theme selection for CLI

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -27,10 +27,19 @@ type PreReleaseHookConfig struct {
 // Config is the main configuration structure for sley.
 type Config struct {
 	Path            string                            `yaml:"path"`
+	Theme           string                            `yaml:"theme,omitempty"`
 	Plugins         *PluginConfig                     `yaml:"plugins,omitempty"`
 	Extensions      []ExtensionConfig                 `yaml:"extensions,omitempty"`
 	PreReleaseHooks []map[string]PreReleaseHookConfig `yaml:"pre-release-hooks,omitempty"`
 	Workspace       *WorkspaceConfig                  `yaml:"workspace,omitempty"`
+}
+
+// GetTheme returns the configured theme name, defaulting to "sley" if not set.
+func (c *Config) GetTheme() string {
+	if c.Theme == "" {
+		return "sley"
+	}
+	return c.Theme
 }
 
 // FileOpener abstracts file opening operations for testability.

--- a/internal/config/config_load_test.go
+++ b/internal/config/config_load_test.go
@@ -110,6 +110,85 @@ func TestLoadConfig(t *testing.T) {
 }
 
 /* ------------------------------------------------------------------------- */
+/* THEME CONFIGURATION                                                       */
+/* ------------------------------------------------------------------------- */
+
+func TestLoadConfigWithTheme(t *testing.T) {
+	t.Run("valid yaml file with theme", func(t *testing.T) {
+		content := "path: .version\ntheme: dracula\n"
+		tmpPath := testutils.WriteTempConfig(t, content)
+		runInTempDir(t, tmpPath, func() {
+			cfg, err := LoadConfigFn()
+			checkError(t, err, false)
+			checkConfigNil(t, cfg, false)
+			if cfg.Theme != "dracula" {
+				t.Errorf("expected theme 'dracula', got %q", cfg.Theme)
+			}
+		})
+	})
+
+	t.Run("empty theme in config", func(t *testing.T) {
+		content := "path: .version\n"
+		tmpPath := testutils.WriteTempConfig(t, content)
+		runInTempDir(t, tmpPath, func() {
+			cfg, err := LoadConfigFn()
+			checkError(t, err, false)
+			checkConfigNil(t, cfg, false)
+			if cfg.Theme != "" {
+				t.Errorf("expected empty theme, got %q", cfg.Theme)
+			}
+		})
+	})
+
+	t.Run("explicit empty theme", func(t *testing.T) {
+		content := "path: .version\ntheme: \"\"\n"
+		tmpPath := testutils.WriteTempConfig(t, content)
+		runInTempDir(t, tmpPath, func() {
+			cfg, err := LoadConfigFn()
+			checkError(t, err, false)
+			checkConfigNil(t, cfg, false)
+			if cfg.Theme != "" {
+				t.Errorf("expected empty theme, got %q", cfg.Theme)
+			}
+		})
+	})
+}
+
+func TestGetTheme(t *testing.T) {
+	tests := []struct {
+		name     string
+		theme    string
+		expected string
+	}{
+		{
+			name:     "empty theme returns default",
+			theme:    "",
+			expected: "sley",
+		},
+		{
+			name:     "custom theme is preserved",
+			theme:    "dracula",
+			expected: "dracula",
+		},
+		{
+			name:     "sley theme is preserved",
+			theme:    "sley",
+			expected: "sley",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := &Config{Theme: tt.theme}
+			got := cfg.GetTheme()
+			if got != tt.expected {
+				t.Errorf("GetTheme() = %q, want %q", got, tt.expected)
+			}
+		})
+	}
+}
+
+/* ------------------------------------------------------------------------- */
 /* NORMALIZE VERSION PATH                                                    */
 /* ------------------------------------------------------------------------- */
 

--- a/internal/tui/prompt.go
+++ b/internal/tui/prompt.go
@@ -98,7 +98,7 @@ func (p *ModulePrompt) showInitialPrompt() (Choice, error) {
 				).
 				Value(&choice),
 		),
-	).WithTheme(sleyTheme()).WithKeyMap(CustomKeyMap())
+	).WithTheme(currentThemeOrDefault()).WithKeyMap(CustomKeyMap())
 
 	if err := form.Run(); err != nil {
 		// User pressed Escape or Ctrl+C
@@ -129,7 +129,7 @@ func (p *ModulePrompt) showMultiSelect() (Selection, error) {
 				Options(options...).
 				Value(&selected),
 		),
-	).WithTheme(sleyTheme()).WithKeyMap(CustomKeyMap())
+	).WithTheme(currentThemeOrDefault()).WithKeyMap(CustomKeyMap())
 
 	if err := form.Run(); err != nil {
 		// User pressed Escape or Ctrl+C
@@ -166,7 +166,7 @@ func Confirm(title, description string) (bool, error) {
 
 	form := huh.NewForm(
 		huh.NewGroup(confirm),
-	).WithTheme(sleyTheme()).WithKeyMap(CustomKeyMap())
+	).WithTheme(currentThemeOrDefault()).WithKeyMap(CustomKeyMap())
 
 	if err := form.Run(); err != nil {
 		// User pressed Escape or Ctrl+C - treat as declined
@@ -195,7 +195,7 @@ func Select[T comparable](title, description string, options []huh.Option[T]) (T
 
 	form := huh.NewForm(
 		huh.NewGroup(selectField),
-	).WithTheme(sleyTheme()).WithKeyMap(CustomKeyMap())
+	).WithTheme(currentThemeOrDefault()).WithKeyMap(CustomKeyMap())
 
 	if err := form.Run(); err != nil {
 		// User pressed Escape or Ctrl+C - return zero value
@@ -226,7 +226,7 @@ func MultiSelect[T comparable](title, description string, options []huh.Option[T
 
 	form := huh.NewForm(
 		huh.NewGroup(multiSelectField),
-	).WithTheme(sleyTheme()).WithKeyMap(CustomKeyMap())
+	).WithTheme(currentThemeOrDefault()).WithKeyMap(CustomKeyMap())
 
 	if err := form.Run(); err != nil {
 		// User pressed Escape or Ctrl+C

--- a/internal/tui/theme.go
+++ b/internal/tui/theme.go
@@ -2,114 +2,39 @@ package tui
 
 import (
 	"github.com/charmbracelet/huh"
-	"github.com/charmbracelet/lipgloss"
 )
 
-// Sley brand colors with adaptive light/dark support
-var (
-	// Primary teal - use darker shades on light bg, lighter on dark bg
-	sleyTealPrimary = lipgloss.AdaptiveColor{Light: "#0d9488", Dark: "#14b8a6"}
-	sleyTealBright  = lipgloss.AdaptiveColor{Light: "#0f766e", Dark: "#2dd4bf"}
-	sleyTealAccent  = lipgloss.AdaptiveColor{Light: "#115e59", Dark: "#5eead4"}
+// currentTheme holds the currently configured theme for TUI components.
+// When nil, currentThemeOrDefault() returns the default sleyTheme.
+var currentTheme *huh.Theme
 
-	// Text colors - high contrast for readability
-	sleyTextStrong = lipgloss.AdaptiveColor{Light: "#0f172a", Dark: "#f1f5f9"}
-	sleyTextNormal = lipgloss.AdaptiveColor{Light: "#334155", Dark: "#cbd5e1"}
-	sleyTextMuted  = lipgloss.AdaptiveColor{Light: "#64748b", Dark: "#94a3b8"}
-	sleyTextFaint  = lipgloss.AdaptiveColor{Light: "#94a3b8", Dark: "#64748b"}
+// SetTheme sets the current theme by name.
+// If the name is invalid or empty, the sley theme is used.
+func SetTheme(name string) {
+	if name == "" {
+		currentTheme = nil
+		return
+	}
+	theme := GetTheme(name)
+	if theme != nil {
+		currentTheme = theme
+	} else {
+		// Fall back to sley theme for invalid names
+		currentTheme = nil
+	}
+}
 
-	// Borders and separators
-	sleyBorderFocused = lipgloss.AdaptiveColor{Light: "#0d9488", Dark: "#14b8a6"}
-	sleyBorderNormal  = lipgloss.AdaptiveColor{Light: "#cbd5e1", Dark: "#475569"}
+// currentThemeOrDefault returns the current theme for TUI components.
+// Returns the sley theme if no theme has been set.
+func currentThemeOrDefault() *huh.Theme {
+	if currentTheme == nil {
+		return sleyTheme()
+	}
+	return currentTheme
+}
 
-	// Button backgrounds
-	sleyButtonBg        = lipgloss.AdaptiveColor{Light: "#0d9488", Dark: "#14b8a6"}
-	sleyButtonBgBlurred = lipgloss.AdaptiveColor{Light: "#e2e8f0", Dark: "#334155"}
-
-	// Button text
-	sleyButtonText        = lipgloss.AdaptiveColor{Light: "#ffffff", Dark: "#0f172a"}
-	sleyButtonTextBlurred = lipgloss.AdaptiveColor{Light: "#64748b", Dark: "#94a3b8"}
-)
-
-// sleyTheme returns a huh theme with sley brand colors
-func sleyTheme() *huh.Theme {
-	t := huh.ThemeBase()
-
-	// Focused state styles
-	t.Focused.Title = t.Focused.Title.
-		Foreground(sleyTealBright).
-		Bold(true)
-
-	t.Focused.Description = t.Focused.Description.
-		Foreground(sleyTextMuted)
-
-	t.Focused.Base = t.Focused.Base.
-		BorderForeground(sleyBorderFocused).
-		BorderStyle(lipgloss.RoundedBorder())
-
-	t.Focused.SelectedOption = t.Focused.SelectedOption.
-		Foreground(sleyTealBright)
-
-	t.Focused.SelectSelector = t.Focused.SelectSelector.
-		Foreground(sleyTealPrimary)
-
-	t.Focused.Option = t.Focused.Option.
-		Foreground(sleyTextNormal)
-
-	t.Focused.FocusedButton = t.Focused.FocusedButton.
-		Foreground(sleyButtonText).
-		Background(sleyButtonBg).
-		Bold(true).
-		Padding(0, 1)
-
-	t.Focused.BlurredButton = t.Focused.BlurredButton.
-		Foreground(sleyButtonTextBlurred).
-		Background(sleyButtonBgBlurred).
-		Padding(0, 1)
-
-	t.Focused.TextInput.Cursor = t.Focused.TextInput.Cursor.
-		Foreground(sleyTealAccent)
-
-	t.Focused.TextInput.Placeholder = t.Focused.TextInput.Placeholder.
-		Foreground(sleyTextFaint)
-
-	t.Focused.TextInput.Prompt = t.Focused.TextInput.Prompt.
-		Foreground(sleyTealPrimary)
-
-	// Blurred state styles
-	t.Blurred.Title = t.Blurred.Title.
-		Foreground(sleyTextStrong)
-
-	t.Blurred.Description = t.Blurred.Description.
-		Foreground(sleyTextFaint)
-
-	t.Blurred.Base = t.Blurred.Base.
-		BorderForeground(sleyBorderNormal)
-
-	t.Blurred.SelectedOption = t.Blurred.SelectedOption.
-		Foreground(sleyTextMuted)
-
-	t.Blurred.Option = t.Blurred.Option.
-		Foreground(sleyTextFaint)
-
-	// Help styles
-	t.Help.ShortKey = t.Help.ShortKey.
-		Foreground(sleyTealPrimary)
-
-	t.Help.ShortDesc = t.Help.ShortDesc.
-		Foreground(sleyTextFaint)
-
-	t.Help.ShortSeparator = t.Help.ShortSeparator.
-		Foreground(sleyBorderNormal)
-
-	t.Help.FullKey = t.Help.FullKey.
-		Foreground(sleyTealPrimary)
-
-	t.Help.FullDesc = t.Help.FullDesc.
-		Foreground(sleyTextMuted)
-
-	t.Help.FullSeparator = t.Help.FullSeparator.
-		Foreground(sleyBorderNormal)
-
-	return t
+// resetTheme resets the current theme to the default (sley).
+// This is primarily useful for testing.
+func resetTheme() {
+	currentTheme = nil
 }

--- a/internal/tui/theme_sley.go
+++ b/internal/tui/theme_sley.go
@@ -1,0 +1,115 @@
+package tui
+
+import (
+	"github.com/charmbracelet/huh"
+	"github.com/charmbracelet/lipgloss"
+)
+
+// Sley brand colors with adaptive light/dark support
+var (
+	// Primary teal - use darker shades on light bg, lighter on dark bg
+	sleyTealPrimary = lipgloss.AdaptiveColor{Light: "#0d9488", Dark: "#14b8a6"}
+	sleyTealBright  = lipgloss.AdaptiveColor{Light: "#0f766e", Dark: "#2dd4bf"}
+	sleyTealAccent  = lipgloss.AdaptiveColor{Light: "#115e59", Dark: "#5eead4"}
+
+	// Text colors - high contrast for readability
+	sleyTextStrong = lipgloss.AdaptiveColor{Light: "#0f172a", Dark: "#f1f5f9"}
+	sleyTextNormal = lipgloss.AdaptiveColor{Light: "#334155", Dark: "#cbd5e1"}
+	sleyTextMuted  = lipgloss.AdaptiveColor{Light: "#64748b", Dark: "#94a3b8"}
+	sleyTextFaint  = lipgloss.AdaptiveColor{Light: "#94a3b8", Dark: "#64748b"}
+
+	// Borders and separators
+	sleyBorderFocused = lipgloss.AdaptiveColor{Light: "#0d9488", Dark: "#14b8a6"}
+	sleyBorderNormal  = lipgloss.AdaptiveColor{Light: "#cbd5e1", Dark: "#475569"}
+
+	// Button backgrounds
+	sleyButtonBg        = lipgloss.AdaptiveColor{Light: "#0d9488", Dark: "#14b8a6"}
+	sleyButtonBgBlurred = lipgloss.AdaptiveColor{Light: "#e2e8f0", Dark: "#334155"}
+
+	// Button text
+	sleyButtonText        = lipgloss.AdaptiveColor{Light: "#ffffff", Dark: "#0f172a"}
+	sleyButtonTextBlurred = lipgloss.AdaptiveColor{Light: "#64748b", Dark: "#94a3b8"}
+)
+
+// sleyTheme returns a huh theme with sley brand colors
+func sleyTheme() *huh.Theme {
+	t := huh.ThemeBase()
+
+	// Focused state styles
+	t.Focused.Title = t.Focused.Title.
+		Foreground(sleyTealBright).
+		Bold(true)
+
+	t.Focused.Description = t.Focused.Description.
+		Foreground(sleyTextMuted)
+
+	t.Focused.Base = t.Focused.Base.
+		BorderForeground(sleyBorderFocused).
+		BorderStyle(lipgloss.RoundedBorder())
+
+	t.Focused.SelectedOption = t.Focused.SelectedOption.
+		Foreground(sleyTealBright)
+
+	t.Focused.SelectSelector = t.Focused.SelectSelector.
+		Foreground(sleyTealPrimary)
+
+	t.Focused.Option = t.Focused.Option.
+		Foreground(sleyTextNormal)
+
+	t.Focused.FocusedButton = t.Focused.FocusedButton.
+		Foreground(sleyButtonText).
+		Background(sleyButtonBg).
+		Bold(true).
+		Padding(0, 1)
+
+	t.Focused.BlurredButton = t.Focused.BlurredButton.
+		Foreground(sleyButtonTextBlurred).
+		Background(sleyButtonBgBlurred).
+		Padding(0, 1)
+
+	t.Focused.TextInput.Cursor = t.Focused.TextInput.Cursor.
+		Foreground(sleyTealAccent)
+
+	t.Focused.TextInput.Placeholder = t.Focused.TextInput.Placeholder.
+		Foreground(sleyTextFaint)
+
+	t.Focused.TextInput.Prompt = t.Focused.TextInput.Prompt.
+		Foreground(sleyTealPrimary)
+
+	// Blurred state styles
+	t.Blurred.Title = t.Blurred.Title.
+		Foreground(sleyTextStrong)
+
+	t.Blurred.Description = t.Blurred.Description.
+		Foreground(sleyTextFaint)
+
+	t.Blurred.Base = t.Blurred.Base.
+		BorderForeground(sleyBorderNormal)
+
+	t.Blurred.SelectedOption = t.Blurred.SelectedOption.
+		Foreground(sleyTextMuted)
+
+	t.Blurred.Option = t.Blurred.Option.
+		Foreground(sleyTextFaint)
+
+	// Help styles
+	t.Help.ShortKey = t.Help.ShortKey.
+		Foreground(sleyTealPrimary)
+
+	t.Help.ShortDesc = t.Help.ShortDesc.
+		Foreground(sleyTextFaint)
+
+	t.Help.ShortSeparator = t.Help.ShortSeparator.
+		Foreground(sleyBorderNormal)
+
+	t.Help.FullKey = t.Help.FullKey.
+		Foreground(sleyTealPrimary)
+
+	t.Help.FullDesc = t.Help.FullDesc.
+		Foreground(sleyTextMuted)
+
+	t.Help.FullSeparator = t.Help.FullSeparator.
+		Foreground(sleyBorderNormal)
+
+	return t
+}

--- a/internal/tui/themes.go
+++ b/internal/tui/themes.go
@@ -1,0 +1,43 @@
+package tui
+
+import (
+	"slices"
+
+	"github.com/charmbracelet/huh"
+)
+
+// ValidThemes is the list of supported theme names.
+var ValidThemes = []string{
+	"sley",
+	"base",
+	"base16",
+	"catppuccin",
+	"charm",
+	"dracula",
+}
+
+// IsValidTheme returns true if the given theme name is valid.
+func IsValidTheme(name string) bool {
+	return slices.Contains(ValidThemes, name)
+}
+
+// GetTheme returns the huh.Theme for the given theme name.
+// Returns nil if the theme name is not recognized.
+func GetTheme(name string) *huh.Theme {
+	switch name {
+	case "sley":
+		return sleyTheme()
+	case "base":
+		return huh.ThemeBase()
+	case "base16":
+		return huh.ThemeBase16()
+	case "catppuccin":
+		return huh.ThemeCatppuccin()
+	case "charm":
+		return huh.ThemeCharm()
+	case "dracula":
+		return huh.ThemeDracula()
+	default:
+		return nil
+	}
+}

--- a/internal/tui/themes_test.go
+++ b/internal/tui/themes_test.go
@@ -1,0 +1,224 @@
+package tui
+
+import (
+	"testing"
+)
+
+func TestValidThemes(t *testing.T) {
+	expected := []string{"sley", "base", "base16", "catppuccin", "charm", "dracula"}
+
+	if len(ValidThemes) != len(expected) {
+		t.Errorf("expected %d valid themes, got %d", len(expected), len(ValidThemes))
+	}
+
+	for i, theme := range expected {
+		if ValidThemes[i] != theme {
+			t.Errorf("expected theme at index %d to be %q, got %q", i, theme, ValidThemes[i])
+		}
+	}
+}
+
+func TestIsValidTheme(t *testing.T) {
+	tests := []struct {
+		name     string
+		theme    string
+		expected bool
+	}{
+		{
+			name:     "sley theme is valid",
+			theme:    "sley",
+			expected: true,
+		},
+		{
+			name:     "base theme is valid",
+			theme:    "base",
+			expected: true,
+		},
+		{
+			name:     "base16 theme is valid",
+			theme:    "base16",
+			expected: true,
+		},
+		{
+			name:     "catppuccin theme is valid",
+			theme:    "catppuccin",
+			expected: true,
+		},
+		{
+			name:     "charm theme is valid",
+			theme:    "charm",
+			expected: true,
+		},
+		{
+			name:     "dracula theme is valid",
+			theme:    "dracula",
+			expected: true,
+		},
+		{
+			name:     "empty string is invalid",
+			theme:    "",
+			expected: false,
+		},
+		{
+			name:     "unknown theme is invalid",
+			theme:    "unknown",
+			expected: false,
+		},
+		{
+			name:     "case sensitive - SLEY is invalid",
+			theme:    "SLEY",
+			expected: false,
+		},
+		{
+			name:     "case sensitive - Dracula is invalid",
+			theme:    "Dracula",
+			expected: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := IsValidTheme(tt.theme)
+			if got != tt.expected {
+				t.Errorf("IsValidTheme(%q) = %v, want %v", tt.theme, got, tt.expected)
+			}
+		})
+	}
+}
+
+func TestGetTheme(t *testing.T) {
+	tests := []struct {
+		name        string
+		theme       string
+		expectNil   bool
+		description string
+	}{
+		{
+			name:        "sley theme returns non-nil",
+			theme:       "sley",
+			expectNil:   false,
+			description: "sley theme should return the custom sley theme",
+		},
+		{
+			name:        "base theme returns non-nil",
+			theme:       "base",
+			expectNil:   false,
+			description: "base theme should return huh.ThemeBase()",
+		},
+		{
+			name:        "base16 theme returns non-nil",
+			theme:       "base16",
+			expectNil:   false,
+			description: "base16 theme should return huh.ThemeBase16()",
+		},
+		{
+			name:        "catppuccin theme returns non-nil",
+			theme:       "catppuccin",
+			expectNil:   false,
+			description: "catppuccin theme should return huh.ThemeCatppuccin()",
+		},
+		{
+			name:        "charm theme returns non-nil",
+			theme:       "charm",
+			expectNil:   false,
+			description: "charm theme should return huh.ThemeCharm()",
+		},
+		{
+			name:        "dracula theme returns non-nil",
+			theme:       "dracula",
+			expectNil:   false,
+			description: "dracula theme should return huh.ThemeDracula()",
+		},
+		{
+			name:        "empty string returns nil",
+			theme:       "",
+			expectNil:   true,
+			description: "empty theme name should return nil",
+		},
+		{
+			name:        "unknown theme returns nil",
+			theme:       "unknown",
+			expectNil:   true,
+			description: "unknown theme name should return nil",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := GetTheme(tt.theme)
+			if tt.expectNil && got != nil {
+				t.Errorf("GetTheme(%q) returned non-nil, want nil: %s", tt.theme, tt.description)
+			}
+			if !tt.expectNil && got == nil {
+				t.Errorf("GetTheme(%q) returned nil, want non-nil: %s", tt.theme, tt.description)
+			}
+		})
+	}
+}
+
+func TestSetTheme(t *testing.T) {
+	// Reset theme after each test
+	defer resetTheme()
+
+	t.Run("set valid theme", func(t *testing.T) {
+		SetTheme("dracula")
+		theme := currentThemeOrDefault()
+		if theme == nil {
+			t.Error("currentThemeOrDefault() returned nil after SetTheme(\"dracula\")")
+		}
+	})
+
+	t.Run("set empty string resets to default", func(t *testing.T) {
+		SetTheme("dracula") // First set a non-default theme
+		SetTheme("")        // Reset to default
+		theme := currentThemeOrDefault()
+		if theme == nil {
+			t.Error("currentThemeOrDefault() returned nil after SetTheme(\"\")")
+		}
+		// The theme should be the sley theme (default)
+	})
+
+	t.Run("set invalid theme falls back to default", func(t *testing.T) {
+		SetTheme("invalid-theme")
+		theme := currentThemeOrDefault()
+		if theme == nil {
+			t.Error("currentThemeOrDefault() returned nil after SetTheme(\"invalid-theme\")")
+		}
+		// Should fall back to sley theme
+	})
+}
+
+func TestCurrentTheme(t *testing.T) {
+	// Reset theme after each test
+	defer resetTheme()
+
+	t.Run("returns default theme when not set", func(t *testing.T) {
+		resetTheme()
+		theme := currentThemeOrDefault()
+		if theme == nil {
+			t.Error("currentThemeOrDefault() returned nil when no theme is set")
+		}
+	})
+
+	t.Run("returns set theme", func(t *testing.T) {
+		SetTheme("charm")
+		theme := currentThemeOrDefault()
+		if theme == nil {
+			t.Error("currentThemeOrDefault() returned nil after setting charm theme")
+		}
+	})
+}
+
+func TestResetTheme(t *testing.T) {
+	// Set a theme first
+	SetTheme("dracula")
+
+	// Reset
+	resetTheme()
+
+	// Verify we're back to default
+	theme := currentThemeOrDefault()
+	if theme == nil {
+		t.Error("currentThemeOrDefault() returned nil after resetTheme()")
+	}
+}


### PR DESCRIPTION
## Description

Add support for configurable TUI themes, allowing users to customize the CLI appearance. The custom "sley" theme remains the default, with additional available themes from `charmbracelet/huh`.

**Configuration methods (priority order):**

1. CLI flag: `--theme <name>`
2. Environment variable: `SLEY_THEME`
3. Config file: `theme` in `.sley.yaml`

**Available themes:** `sley` (default), `base`, `base16`, `catppuccin`, `charm`, `dracula`

## Related Issue

 - None

## Notes for Reviewers

- None
