### PR TITLE
refactor: replace BumpNextFunc/BumpByLabelFunc globals with VersionBumper interface

### DIFF
--- a/internal/commands/bump/auto.go
+++ b/internal/commands/bump/auto.go
@@ -20,6 +20,12 @@ import (
 var (
 	tryInferBumpTypeFromCommitParserPluginFn    = tryInferBumpTypeFromCommitParserPlugin
 	tryInferBumpTypeFromChangelogParserPluginFn = tryInferBumpTypeFromChangelogParserPlugin
+
+	// newVersionBumper creates the VersionBumper used for auto bump operations.
+	// Tests can override this to inject mock bumpers.
+	newVersionBumper = func() semver.VersionBumper {
+		return semver.NewDefaultBumper()
+	}
 )
 
 // autoCmd returns the "auto" subcommand.
@@ -155,7 +161,8 @@ func runSingleModuleAuto(ctx context.Context, cmd *cli.Command, cfg *config.Conf
 		return fmt.Errorf("failed to read version: %w", err)
 	}
 
-	next, err := getNextVersion(registry, current, label, disableInfer, since, until, isPreserveMeta)
+	bumper := newVersionBumper()
+	next, err := getNextVersion(bumper, registry, current, label, disableInfer, since, until, isPreserveMeta)
 	if err != nil {
 		return err
 	}
@@ -213,6 +220,7 @@ func runSingleModuleAuto(ctx context.Context, cmd *cli.Command, cfg *config.Conf
 // commit inference, or default bump logic. It returns an error if bumping fails
 // or if an invalid label is specified.
 func getNextVersion(
+	bumper semver.VersionBumper,
 	registry *plugins.PluginRegistry,
 	current semver.SemVersion,
 	label string,
@@ -225,7 +233,7 @@ func getNextVersion(
 
 	switch label {
 	case "patch", "minor", "major":
-		next, err = semver.BumpByLabelFunc(current, label)
+		next, err = bumper.BumpByLabel(current, label)
 		if err != nil {
 			return semver.SemVersion{}, fmt.Errorf("failed to bump version with label: %w", err)
 		}
@@ -244,7 +252,7 @@ func getNextVersion(
 				if current.PreRelease != "" {
 					return promotePreRelease(current, preserveMeta), nil
 				}
-				next, err = semver.BumpByLabelFunc(current, inferred)
+				next, err = bumper.BumpByLabel(current, inferred)
 				if err != nil {
 					return semver.SemVersion{}, fmt.Errorf("failed to bump inferred version: %w", err)
 				}
@@ -252,7 +260,7 @@ func getNextVersion(
 			}
 		}
 
-		next, err = semver.BumpNextFunc(current)
+		next, err = bumper.BumpNext(current)
 		if err != nil {
 			return semver.SemVersion{}, fmt.Errorf("failed to determine next version: %w", err)
 		}

--- a/internal/commands/bump/bump_auto_test.go
+++ b/internal/commands/bump/bump_auto_test.go
@@ -248,16 +248,36 @@ func TestCLI_BumpAutoCmd_PromotePreReleaseWithPreserveMeta(t *testing.T) {
 	}
 }
 
+// mockBumper is a VersionBumper for testing that returns configurable results.
+type mockBumper struct {
+	bumpNextErr    error
+	bumpByLabelErr error
+}
+
+func (m mockBumper) BumpNext(v semver.SemVersion) (semver.SemVersion, error) {
+	if m.bumpNextErr != nil {
+		return semver.SemVersion{}, m.bumpNextErr
+	}
+	return semver.BumpNext(v)
+}
+
+func (m mockBumper) BumpByLabel(v semver.SemVersion, label string) (semver.SemVersion, error) {
+	if m.bumpByLabelErr != nil {
+		return semver.SemVersion{}, m.bumpByLabelErr
+	}
+	return semver.BumpByLabel(v, label)
+}
+
 func TestCLI_BumpAutoCmd_InferredBumpFails(t *testing.T) {
 	tmp := t.TempDir()
 	versionPath := testutils.WriteTempVersionFile(t, tmp, "1.2.3")
 
-	originalBumpByLabel := semver.BumpByLabelFunc
+	originalBumperFactory := newVersionBumper
 	originalInferFunc := tryInferBumpTypeFromCommitParserPluginFn
 
-	// Force BumpByLabelFunc to fail
-	semver.BumpByLabelFunc = func(v semver.SemVersion, label string) (semver.SemVersion, error) {
-		return semver.SemVersion{}, fmt.Errorf("forced inferred bump failure")
+	// Force BumpByLabel to fail via mock bumper
+	newVersionBumper = func() semver.VersionBumper {
+		return mockBumper{bumpByLabelErr: fmt.Errorf("forced inferred bump failure")}
 	}
 
 	// Force inference to return something
@@ -266,7 +286,7 @@ func TestCLI_BumpAutoCmd_InferredBumpFails(t *testing.T) {
 	}
 
 	t.Cleanup(func() {
-		semver.BumpByLabelFunc = originalBumpByLabel
+		newVersionBumper = originalBumperFactory
 		tryInferBumpTypeFromCommitParserPluginFn = originalInferFunc
 	})
 
@@ -435,12 +455,12 @@ func TestCLI_BumpAutoCmd_BumpNextFails(t *testing.T) {
 	tmp := t.TempDir()
 	versionPath := testutils.WriteTempVersionFile(t, tmp, "1.2.3")
 
-	original := semver.BumpNextFunc
-	semver.BumpNextFunc = func(v semver.SemVersion) (semver.SemVersion, error) {
-		return semver.SemVersion{}, fmt.Errorf("forced BumpNext failure")
+	originalBumperFactory := newVersionBumper
+	newVersionBumper = func() semver.VersionBumper {
+		return mockBumper{bumpNextErr: fmt.Errorf("forced BumpNext failure")}
 	}
 	t.Cleanup(func() {
-		semver.BumpNextFunc = original
+		newVersionBumper = originalBumperFactory
 	})
 
 	// Prepare and run the CLI command
@@ -524,12 +544,12 @@ func TestCLI_BumpAutoCmd_BumpByLabelFails(t *testing.T) {
 	tmp := t.TempDir()
 	versionPath := testutils.WriteTempVersionFile(t, tmp, "1.2.3")
 
-	original := semver.BumpByLabelFunc
-	semver.BumpByLabelFunc = func(v semver.SemVersion, label string) (semver.SemVersion, error) {
-		return semver.SemVersion{}, fmt.Errorf("boom")
+	originalBumperFactory := newVersionBumper
+	newVersionBumper = func() semver.VersionBumper {
+		return mockBumper{bumpByLabelErr: fmt.Errorf("boom")}
 	}
 	t.Cleanup(func() {
-		semver.BumpByLabelFunc = original
+		newVersionBumper = originalBumperFactory
 	})
 
 	// Prepare and run the CLI command
@@ -652,7 +672,8 @@ func TestGetNextVersion(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			registry := plugins.NewPluginRegistry()
-			result, err := getNextVersion(registry, tt.current, tt.label, tt.disableInfer, "", "", false)
+			bumper := semver.NewDefaultBumper()
+			result, err := getNextVersion(bumper, registry, tt.current, tt.label, tt.disableInfer, "", "", false)
 			if tt.expectError {
 				if err == nil {
 					t.Error("expected error, got nil")

--- a/internal/commands/bump/multimodule.go
+++ b/internal/commands/bump/multimodule.go
@@ -26,7 +26,8 @@ func runMultiModuleBump(
 	preserveMetadata bool,
 ) error {
 	fs := core.NewOSFileSystem()
-	operation := operations.NewBumpOperation(fs, bumpType, preRelease, metadata, preserveMetadata)
+	bumper := newVersionBumper()
+	operation := operations.NewBumpOperation(fs, bumper, bumpType, preRelease, metadata, preserveMetadata)
 
 	// Create executor with options from flags
 	parallel := cmd.Bool("parallel")

--- a/internal/operations/bump.go
+++ b/internal/operations/bump.go
@@ -25,6 +25,7 @@ const (
 // BumpOperation performs a version bump on a module.
 type BumpOperation struct {
 	fs               core.FileSystem
+	bumper           semver.VersionBumper
 	bumpType         BumpType
 	preRelease       string
 	metadata         string
@@ -32,9 +33,10 @@ type BumpOperation struct {
 }
 
 // NewBumpOperation creates a new bump operation.
-func NewBumpOperation(fs core.FileSystem, bumpType BumpType, preRelease, metadata string, preserveMetadata bool) *BumpOperation {
+func NewBumpOperation(fs core.FileSystem, bumper semver.VersionBumper, bumpType BumpType, preRelease, metadata string, preserveMetadata bool) *BumpOperation {
 	return &BumpOperation{
 		fs:               fs,
+		bumper:           bumper,
 		bumpType:         bumpType,
 		preRelease:       preRelease,
 		metadata:         metadata,
@@ -135,7 +137,7 @@ func (op *BumpOperation) bumpRelease(current semver.SemVersion) semver.SemVersio
 }
 
 func (op *BumpOperation) bumpAuto(current semver.SemVersion) (semver.SemVersion, error) {
-	newVer, err := semver.BumpNextFunc(current)
+	newVer, err := op.bumper.BumpNext(current)
 	if err != nil {
 		return semver.SemVersion{}, fmt.Errorf("auto bump failed: %w", err)
 	}

--- a/internal/operations/bump_test.go
+++ b/internal/operations/bump_test.go
@@ -12,7 +12,7 @@ import (
 
 func TestNewBumpOperation(t *testing.T) {
 	fs := core.NewMockFileSystem()
-	op := NewBumpOperation(fs, BumpPatch, "alpha", "build123", true)
+	op := NewBumpOperation(fs, semver.NewDefaultBumper(), BumpPatch, "alpha", "build123", true)
 
 	if op == nil {
 		t.Fatal("NewBumpOperation returned nil")
@@ -20,6 +20,9 @@ func TestNewBumpOperation(t *testing.T) {
 	}
 	if op.fs == nil {
 		t.Error("fs is nil")
+	}
+	if op.bumper == nil {
+		t.Error("bumper is nil")
 	}
 	if op.bumpType != BumpPatch {
 		t.Errorf("bumpType = %v, want %v", op.bumpType, BumpPatch)
@@ -39,7 +42,7 @@ func TestBumpOperation_Execute_Patch(t *testing.T) {
 	fs := core.NewMockFileSystem()
 	fs.SetFile("/test/.version", []byte("1.2.3\n"))
 
-	op := NewBumpOperation(fs, BumpPatch, "", "", false)
+	op := NewBumpOperation(fs, semver.NewDefaultBumper(), BumpPatch, "", "", false)
 	mod := &workspace.Module{
 		Name: "test",
 		Path: "/test/.version",
@@ -70,7 +73,7 @@ func TestBumpOperation_Execute_Minor(t *testing.T) {
 	fs := core.NewMockFileSystem()
 	fs.SetFile("/test/.version", []byte("1.2.3\n"))
 
-	op := NewBumpOperation(fs, BumpMinor, "", "", false)
+	op := NewBumpOperation(fs, semver.NewDefaultBumper(), BumpMinor, "", "", false)
 	mod := &workspace.Module{
 		Name: "test",
 		Path: "/test/.version",
@@ -101,7 +104,7 @@ func TestBumpOperation_Execute_Major(t *testing.T) {
 	fs := core.NewMockFileSystem()
 	fs.SetFile("/test/.version", []byte("1.2.3\n"))
 
-	op := NewBumpOperation(fs, BumpMajor, "", "", false)
+	op := NewBumpOperation(fs, semver.NewDefaultBumper(), BumpMajor, "", "", false)
 	mod := &workspace.Module{
 		Name: "test",
 		Path: "/test/.version",
@@ -132,7 +135,7 @@ func TestBumpOperation_Execute_Release(t *testing.T) {
 	fs := core.NewMockFileSystem()
 	fs.SetFile("/test/.version", []byte("1.2.3-beta.1+build.123\n"))
 
-	op := NewBumpOperation(fs, BumpRelease, "", "", false)
+	op := NewBumpOperation(fs, semver.NewDefaultBumper(), BumpRelease, "", "", false)
 	mod := &workspace.Module{
 		Name: "test",
 		Path: "/test/.version",
@@ -182,7 +185,7 @@ func TestBumpOperation_Execute_Auto(t *testing.T) {
 			fs := core.NewMockFileSystem()
 			fs.SetFile("/test/.version", []byte(tt.initial))
 
-			op := NewBumpOperation(fs, BumpAuto, "", "", false)
+			op := NewBumpOperation(fs, semver.NewDefaultBumper(), BumpAuto, "", "", false)
 			mod := &workspace.Module{
 				Name: "test",
 				Path: "/test/.version",
@@ -210,7 +213,7 @@ func TestBumpOperation_Execute_WithPreRelease(t *testing.T) {
 	fs := core.NewMockFileSystem()
 	fs.SetFile("/test/.version", []byte("1.2.3\n"))
 
-	op := NewBumpOperation(fs, BumpPatch, "alpha.1", "", false)
+	op := NewBumpOperation(fs, semver.NewDefaultBumper(), BumpPatch, "alpha.1", "", false)
 	mod := &workspace.Module{
 		Name: "test",
 		Path: "/test/.version",
@@ -237,7 +240,7 @@ func TestBumpOperation_Execute_WithMetadata(t *testing.T) {
 	fs := core.NewMockFileSystem()
 	fs.SetFile("/test/.version", []byte("1.2.3\n"))
 
-	op := NewBumpOperation(fs, BumpPatch, "", "build.456", false)
+	op := NewBumpOperation(fs, semver.NewDefaultBumper(), BumpPatch, "", "build.456", false)
 	mod := &workspace.Module{
 		Name: "test",
 		Path: "/test/.version",
@@ -303,7 +306,7 @@ func TestBumpOperation_Execute_PreserveMetadata(t *testing.T) {
 			fs := core.NewMockFileSystem()
 			fs.SetFile("/test/.version", []byte(tt.initial))
 
-			op := NewBumpOperation(fs, BumpPatch, "", tt.newMetadata, tt.preserveMetadata)
+			op := NewBumpOperation(fs, semver.NewDefaultBumper(), BumpPatch, "", tt.newMetadata, tt.preserveMetadata)
 			mod := &workspace.Module{
 				Name: "test",
 				Path: "/test/.version",
@@ -331,7 +334,7 @@ func TestBumpOperation_Execute_ContextCancellation(t *testing.T) {
 	fs := core.NewMockFileSystem()
 	fs.SetFile("/test/.version", []byte("1.2.3\n"))
 
-	op := NewBumpOperation(fs, BumpPatch, "", "", false)
+	op := NewBumpOperation(fs, semver.NewDefaultBumper(), BumpPatch, "", "", false)
 	mod := &workspace.Module{
 		Name: "test",
 		Path: "/test/.version",
@@ -353,7 +356,7 @@ func TestBumpOperation_Execute_ContextTimeout(t *testing.T) {
 	fs := core.NewMockFileSystem()
 	fs.SetFile("/test/.version", []byte("1.2.3\n"))
 
-	op := NewBumpOperation(fs, BumpPatch, "", "", false)
+	op := NewBumpOperation(fs, semver.NewDefaultBumper(), BumpPatch, "", "", false)
 	mod := &workspace.Module{
 		Name: "test",
 		Path: "/test/.version",
@@ -374,7 +377,7 @@ func TestBumpOperation_Execute_ReadError(t *testing.T) {
 	fs := core.NewMockFileSystem()
 	// Don't set any file, so read will fail
 
-	op := NewBumpOperation(fs, BumpPatch, "", "", false)
+	op := NewBumpOperation(fs, semver.NewDefaultBumper(), BumpPatch, "", "", false)
 	mod := &workspace.Module{
 		Name: "test",
 		Path: "/test/.version",
@@ -387,20 +390,27 @@ func TestBumpOperation_Execute_ReadError(t *testing.T) {
 	}
 }
 
+// mockErrorBumper is a VersionBumper that always returns errors.
+type mockErrorBumper struct {
+	err error
+}
+
+func (m mockErrorBumper) BumpNext(_ semver.SemVersion) (semver.SemVersion, error) {
+	return semver.SemVersion{}, m.err
+}
+
+func (m mockErrorBumper) BumpByLabel(_ semver.SemVersion, _ string) (semver.SemVersion, error) {
+	return semver.SemVersion{}, m.err
+}
+
 func TestBumpOperation_Execute_AutoBumpError(t *testing.T) {
 	fs := core.NewMockFileSystem()
 	fs.SetFile("/test/.version", []byte("1.2.3\n"))
 
-	// Save original BumpNextFunc and restore after test
-	originalBumpNextFunc := semver.BumpNextFunc
-	defer func() { semver.BumpNextFunc = originalBumpNextFunc }()
+	// Use a mock bumper that returns an error
+	bumper := mockErrorBumper{err: context.DeadlineExceeded}
 
-	// Override BumpNextFunc to return an error
-	semver.BumpNextFunc = func(v semver.SemVersion) (semver.SemVersion, error) {
-		return semver.SemVersion{}, context.DeadlineExceeded
-	}
-
-	op := NewBumpOperation(fs, BumpAuto, "", "", false)
+	op := NewBumpOperation(fs, bumper, BumpAuto, "", "", false)
 	mod := &workspace.Module{
 		Name: "test",
 		Path: "/test/.version",
@@ -417,7 +427,7 @@ func TestBumpOperation_Execute_UnknownBumpType(t *testing.T) {
 	fs := core.NewMockFileSystem()
 	fs.SetFile("/test/.version", []byte("1.2.3\n"))
 
-	op := NewBumpOperation(fs, BumpType("unknown"), "", "", false)
+	op := NewBumpOperation(fs, semver.NewDefaultBumper(), BumpType("unknown"), "", "", false)
 	mod := &workspace.Module{
 		Name: "test",
 		Path: "/test/.version",
@@ -437,7 +447,7 @@ func TestBumpOperation_Execute_SaveError(t *testing.T) {
 	// Inject write error - this will be checked when Save is called
 	fs.WriteErr = context.DeadlineExceeded
 
-	op := NewBumpOperation(fs, BumpPatch, "", "", false)
+	op := NewBumpOperation(fs, semver.NewDefaultBumper(), BumpPatch, "", "", false)
 	mod := &workspace.Module{
 		Name: "test",
 		Path: "/test/.version",
@@ -492,7 +502,7 @@ func TestBumpOperation_Name(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			fs := core.NewMockFileSystem()
-			op := NewBumpOperation(fs, tt.bumpType, "", "", false)
+			op := NewBumpOperation(fs, semver.NewDefaultBumper(), tt.bumpType, "", "", false)
 
 			name := op.Name()
 			if name != tt.expected {
@@ -540,7 +550,7 @@ func TestBumpOperation_Execute_Pre_IncrementExisting(t *testing.T) {
 			fs := core.NewMockFileSystem()
 			fs.SetFile("/test/.version", []byte(tt.initial))
 
-			op := NewBumpOperation(fs, BumpPre, tt.label, "", false)
+			op := NewBumpOperation(fs, semver.NewDefaultBumper(), BumpPre, tt.label, "", false)
 			mod := &workspace.Module{
 				Name: "test",
 				Path: "/test/.version",
@@ -596,7 +606,7 @@ func TestBumpOperation_Execute_Pre_WithLabel(t *testing.T) {
 			fs := core.NewMockFileSystem()
 			fs.SetFile("/test/.version", []byte(tt.initial))
 
-			op := NewBumpOperation(fs, BumpPre, tt.label, "", false)
+			op := NewBumpOperation(fs, semver.NewDefaultBumper(), BumpPre, tt.label, "", false)
 			mod := &workspace.Module{
 				Name: "test",
 				Path: "/test/.version",
@@ -625,7 +635,7 @@ func TestBumpOperation_Execute_Pre_NoExistingPreRelease(t *testing.T) {
 	fs.SetFile("/test/.version", []byte("1.2.3\n"))
 
 	// BumpPre with no label and no existing pre-release should fail
-	op := NewBumpOperation(fs, BumpPre, "", "", false)
+	op := NewBumpOperation(fs, semver.NewDefaultBumper(), BumpPre, "", "", false)
 	mod := &workspace.Module{
 		Name: "test",
 		Path: "/test/.version",
@@ -642,7 +652,7 @@ func TestBumpOperation_Execute_Pre_PreserveMetadata(t *testing.T) {
 	fs := core.NewMockFileSystem()
 	fs.SetFile("/test/.version", []byte("1.2.3-rc.1+build.99\n"))
 
-	op := NewBumpOperation(fs, BumpPre, "", "", true)
+	op := NewBumpOperation(fs, semver.NewDefaultBumper(), BumpPre, "", "", true)
 	mod := &workspace.Module{
 		Name: "test",
 		Path: "/test/.version",
@@ -669,7 +679,7 @@ func TestBumpOperation_Execute_Pre_WithNewMetadata(t *testing.T) {
 	fs := core.NewMockFileSystem()
 	fs.SetFile("/test/.version", []byte("1.2.3-rc.1\n"))
 
-	op := NewBumpOperation(fs, BumpPre, "", "ci.456", false)
+	op := NewBumpOperation(fs, semver.NewDefaultBumper(), BumpPre, "", "ci.456", false)
 	mod := &workspace.Module{
 		Name: "test",
 		Path: "/test/.version",

--- a/internal/semver/bumper.go
+++ b/internal/semver/bumper.go
@@ -1,0 +1,30 @@
+package semver
+
+// VersionBumper abstracts version bumping operations for testability.
+// This enables dependency injection instead of mutable package-level function variables.
+type VersionBumper interface {
+	// BumpNext applies heuristic-based smart bump logic.
+	BumpNext(v SemVersion) (SemVersion, error)
+
+	// BumpByLabel bumps the version using an explicit label (patch, minor, major).
+	BumpByLabel(v SemVersion, label string) (SemVersion, error)
+}
+
+// DefaultBumper is the standard VersionBumper implementation
+// that delegates to the package-level BumpNext and BumpByLabel functions.
+type DefaultBumper struct{}
+
+// NewDefaultBumper creates a new DefaultBumper.
+func NewDefaultBumper() DefaultBumper {
+	return DefaultBumper{}
+}
+
+// BumpNext applies heuristic-based smart bump logic.
+func (DefaultBumper) BumpNext(v SemVersion) (SemVersion, error) {
+	return BumpNext(v)
+}
+
+// BumpByLabel bumps the version using an explicit label.
+func (DefaultBumper) BumpByLabel(v SemVersion, label string) (SemVersion, error) {
+	return BumpByLabel(v, label)
+}

--- a/internal/semver/version.go
+++ b/internal/semver/version.go
@@ -35,14 +35,6 @@ var (
 	// errInvalidVersion is returned when a version string does not conform
 	// to the expected semantic version format.
 	errInvalidVersion = errors.New("invalid version format")
-
-	// BumpNextFunc is a function variable for performing heuristic-based version bumps.
-	// It defaults to BumpNext but can be overridden in tests to simulate errors.
-	BumpNextFunc = BumpNext
-
-	// BumpByLabelFunc is a function variable for bumping a version using an explicit label (patch, minor, major).
-	// It defaults to BumpByLabel but can be overridden in tests to simulate errors.
-	BumpByLabelFunc = BumpByLabel
 )
 
 // String returns the string representation of the semantic version.


### PR DESCRIPTION
## Description

Replace mutable package-level function variables `BumpNextFunc` and `BumpByLabelFunc` in `internal/semver/` with a `VersionBumper` interface and dependency injection. This eliminates global mutable state and follows the existing DI patterns in `internal/core/`.

- Add `VersionBumper` interface + `DefaultBumper` implementation in `internal/semver/`
- Inject `VersionBumper` into `BumpOperation` via constructor
- Add `newVersionBumper` factory at the CLI composition root for testability
- Update tests to use mock bumpers instead of swapping globals

## Related Issue

- None

## Notes for Reviewers

- None
