### PR TITLE
perf: cache templates and pre-allocate maps and slices

### DIFF
--- a/internal/clix/clix.go
+++ b/internal/clix/clix.go
@@ -361,7 +361,7 @@ func filterModulesByName(modules []*workspace.Module, name string) []*workspace.
 
 // filterModulesBySelection filters modules based on user selection.
 func filterModulesBySelection(modules []*workspace.Module, selected []string) []*workspace.Module {
-	selectedMap := make(map[string]bool)
+	selectedMap := make(map[string]bool, len(selected))
 	for _, name := range selected {
 		selectedMap[name] = true
 	}
@@ -383,7 +383,7 @@ func filterModulesByNames(modules []*workspace.Module, names []string) []*worksp
 	}
 
 	// Build a set of names for O(1) lookup
-	nameSet := make(map[string]bool)
+	nameSet := make(map[string]bool, len(names))
 	for _, name := range names {
 		// Handle comma-separated values within a single argument
 		for n := range strings.SplitSeq(name, ",") {

--- a/internal/config/config_workspace.go
+++ b/internal/config/config_workspace.go
@@ -124,7 +124,7 @@ func (c *Config) GetExcludePatterns() []string {
 	// Add configured patterns if they differ from defaults
 	if c.Workspace != nil && c.Workspace.Discovery != nil && len(c.Workspace.Discovery.Exclude) > 0 {
 		// Use a map to avoid duplicates
-		seen := make(map[string]bool)
+		seen := make(map[string]bool, len(DefaultExcludePatterns)+len(c.Workspace.Discovery.Exclude))
 		for _, p := range DefaultExcludePatterns {
 			seen[p] = true
 		}

--- a/internal/config/validator_workspace.go
+++ b/internal/config/validator_workspace.go
@@ -53,7 +53,7 @@ func (v *Validator) validateExplicitModules(ctx context.Context) {
 	modules := v.cfg.Workspace.Modules
 
 	// Check for duplicate module names
-	names := make(map[string]bool)
+	names := make(map[string]bool, len(modules))
 	for i, mod := range modules {
 		if names[mod.Name] {
 			v.addValidation("Workspace: Modules", false,

--- a/internal/discovery/discovery.go
+++ b/internal/discovery/discovery.go
@@ -251,7 +251,7 @@ func (s *Service) shouldExclude(name, path string, excludes []string) bool {
 // Excluded directories (node_modules, vendor, .git, etc.) are skipped.
 func (s *Service) discoverAllManifests(ctx context.Context, root string, maxDepth int) ([]ManifestSource, error) {
 	var manifests []ManifestSource
-	seen := make(map[string]bool) // Track visited paths to avoid duplicates
+	seen := make(map[string]bool, 64) // Track visited paths to avoid duplicates
 	excludes := s.cfg.GetExcludePatterns()
 
 	// Helper function to walk directories recursively

--- a/internal/discovery/mismatch.go
+++ b/internal/discovery/mismatch.go
@@ -94,7 +94,7 @@ func GetUniqueVersions(result *Result) []string {
 		return nil
 	}
 
-	versionSet := make(map[string]struct{})
+	versionSet := make(map[string]struct{}, len(result.Modules)+len(result.Manifests))
 
 	// Collect versions from modules
 	for _, m := range result.Modules {
@@ -150,7 +150,7 @@ func GetVersionSummary(result *Result) []VersionSummary {
 		return nil
 	}
 
-	versionMap := make(map[string][]string)
+	versionMap := make(map[string][]string, len(result.Modules)+len(result.Manifests))
 
 	// Collect versions from modules
 	for _, m := range result.Modules {

--- a/internal/plugins/changeloggenerator/generator.go
+++ b/internal/plugins/changeloggenerator/generator.go
@@ -18,6 +18,10 @@ type Generator struct {
 	config    *Config
 	remote    *RemoteInfo
 	formatter Formatter
+
+	// Template caches to avoid re-parsing on every contributor entry.
+	cachedContribTmpl    *template.Template
+	cachedNewContribTmpl *template.Template
 }
 
 // NewGenerator creates a new changelog generator.
@@ -198,12 +202,17 @@ func (g *Generator) writeContributorEntry(sb *strings.Builder, contrib Contribut
 		format = "- [@{{.Username}}](https://{{.Host}}/{{.Username}})"
 	}
 
-	// Parse and execute template
-	tmpl, err := template.New("contributor").Parse(format)
-	if err != nil {
-		// Fallback on template error
-		fmt.Fprintf(sb, "- [@%s](https://%s/%s)\n", contrib.Username, host, contrib.Username)
-		return
+	// Parse and execute template (use cached template if available)
+	tmpl := g.cachedContribTmpl
+	if tmpl == nil {
+		var parseErr error
+		tmpl, parseErr = template.New("contributor").Parse(format)
+		if parseErr != nil {
+			// Fallback on template error
+			fmt.Fprintf(sb, "- [@%s](https://%s/%s)\n", contrib.Username, host, contrib.Username)
+			return
+		}
+		g.cachedContribTmpl = tmpl
 	}
 
 	data := contributorTemplateData{
@@ -267,12 +276,17 @@ func (g *Generator) writeNewContributorEntry(sb *strings.Builder, nc *NewContrib
 		format = g.getDefaultNewContributorFormat(remote)
 	}
 
-	// Parse and execute template
-	tmpl, err := template.New("newContributor").Parse(format)
-	if err != nil {
-		// Fallback on template error
-		g.writeNewContributorFallback(sb, nc, remote)
-		return
+	// Parse and execute template (use cached template if available)
+	tmpl := g.cachedNewContribTmpl
+	if tmpl == nil {
+		var parseErr error
+		tmpl, parseErr = template.New("newContributor").Parse(format)
+		if parseErr != nil {
+			// Fallback on template error
+			g.writeNewContributorFallback(sb, nc, remote)
+			return
+		}
+		g.cachedNewContribTmpl = tmpl
 	}
 
 	data := newContributorTemplateData{

--- a/internal/plugins/changeloggenerator/git.go
+++ b/internal/plugins/changeloggenerator/git.go
@@ -207,8 +207,8 @@ type Contributor struct {
 
 // getContributors extracts unique contributors from commits.
 func getContributors(commits []CommitInfo) []Contributor {
-	seen := make(map[string]bool)
-	contributors := make([]Contributor, 0)
+	seen := make(map[string]bool, len(commits))
+	contributors := make([]Contributor, 0, len(commits))
 
 	for _, c := range commits {
 		key := c.AuthorEmail
@@ -317,7 +317,7 @@ func getNewContributors(commits []CommitInfo, previousVersion string) ([]NewCont
 	}
 
 	// Track which usernames we've already processed in this release
-	seenInRelease := make(map[string]bool)
+	seenInRelease := make(map[string]bool, len(commits))
 	var newContributors []NewContributor
 
 	for _, commit := range commits {

--- a/internal/workspace/detector.go
+++ b/internal/workspace/detector.go
@@ -173,7 +173,7 @@ func (d *Detector) scanDirectory(ctx context.Context, dir string, depth int, roo
 		return nil, nil
 	}
 
-	var modules []*Module
+	modules := make([]*Module, 0, len(entries)/2)
 
 	for _, entry := range entries {
 		if err := ctx.Err(); err != nil {
@@ -287,7 +287,7 @@ func (d *Detector) loadExplicitModules(ctx context.Context, root string) ([]*Mod
 		return nil, nil
 	}
 
-	var modules []*Module
+	modules := make([]*Module, 0, len(d.cfg.Workspace.Modules))
 	for _, moduleConfig := range d.cfg.Workspace.Modules {
 		// Check for context cancellation during iteration
 		if err := ctx.Err(); err != nil {


### PR DESCRIPTION
## Description

Optimize hot paths by caching parsed templates in the changelog generator and pre-allocating maps/slices with known or estimated capacities across discovery, config, workspace, and plugin packages.

## Related Issue

- None

## Notes for Reviewers

- Template caching in `changeloggenerator/generator.go` avoids re-parsing the same contributor/new-contributor templates on every entry
- All `make(map)` and `make([]T)` calls in hot loops now use capacity hints derived from input sizes
- No behavioral changes; purely allocation reduction
