### PR TITLE
refactor(core): add context to git interfaces and remove type assertions

### DIFF
--- a/internal/commands/bump/bump_commit_tag_test.go
+++ b/internal/commands/bump/bump_commit_tag_test.go
@@ -1,6 +1,7 @@
 package bump
 
 import (
+	"context"
 	"fmt"
 	"strings"
 	"testing"
@@ -50,18 +51,18 @@ func TestCommitAndTagAfterBump_Success(t *testing.T) {
 		Prefix:     "v",
 		Annotate:   true,
 	}, &tagmanager.MockGitTagOperations{
-		TagExistsFn: func(name string) (bool, error) { return false, nil },
-		CreateAnnotatedTagFn: func(name, message string) error {
+		TagExistsFn: func(ctx context.Context, name string) (bool, error) { return false, nil },
+		CreateAnnotatedTagFn: func(ctx context.Context, name, message string) error {
 			createdTag = name
 			return nil
 		},
 	}, &tagmanager.MockGitCommitOperations{
-		GetModifiedFilesFn: func() ([]string, error) { return []string{}, nil },
-		StageFilesFn: func(files ...string) error {
+		GetModifiedFilesFn: func(ctx context.Context) ([]string, error) { return []string{}, nil },
+		StageFilesFn: func(ctx context.Context, files ...string) error {
 			stagedFiles = append(stagedFiles, files...)
 			return nil
 		},
-		CommitFn: func(message string) error {
+		CommitFn: func(ctx context.Context, message string) error {
 			commitMsg = message
 			return nil
 		},
@@ -97,17 +98,17 @@ func TestCommitAndTagAfterBump_WithModifiedFiles(t *testing.T) {
 		Prefix:     "v",
 		Annotate:   true,
 	}, &tagmanager.MockGitTagOperations{
-		TagExistsFn:          func(name string) (bool, error) { return false, nil },
-		CreateAnnotatedTagFn: func(name, message string) error { return nil },
+		TagExistsFn:          func(ctx context.Context, name string) (bool, error) { return false, nil },
+		CreateAnnotatedTagFn: func(ctx context.Context, name, message string) error { return nil },
 	}, &tagmanager.MockGitCommitOperations{
-		GetModifiedFilesFn: func() ([]string, error) {
+		GetModifiedFilesFn: func(ctx context.Context) ([]string, error) {
 			return []string{"CHANGELOG.md", "package.json"}, nil
 		},
-		StageFilesFn: func(files ...string) error {
+		StageFilesFn: func(ctx context.Context, files ...string) error {
 			stagedFiles = append(stagedFiles, files...)
 			return nil
 		},
-		CommitFn: func(message string) error { return nil },
+		CommitFn: func(ctx context.Context, message string) error { return nil },
 	})
 
 	registry := plugins.NewPluginRegistry()
@@ -132,9 +133,9 @@ func TestCommitAndTagAfterBump_CommitFails(t *testing.T) {
 		AutoCreate: true,
 		Prefix:     "v",
 	}, &tagmanager.MockGitTagOperations{}, &tagmanager.MockGitCommitOperations{
-		GetModifiedFilesFn: func() ([]string, error) { return []string{}, nil },
-		StageFilesFn:       func(files ...string) error { return nil },
-		CommitFn:           func(message string) error { return fmt.Errorf("commit failed") },
+		GetModifiedFilesFn: func(ctx context.Context) ([]string, error) { return []string{}, nil },
+		StageFilesFn:       func(ctx context.Context, files ...string) error { return nil },
+		CommitFn:           func(ctx context.Context, message string) error { return fmt.Errorf("commit failed") },
 	})
 
 	registry := plugins.NewPluginRegistry()
@@ -159,12 +160,12 @@ func TestCommitAndTagAfterBump_TagCreationFails(t *testing.T) {
 		Prefix:     "v",
 		Annotate:   true,
 	}, &tagmanager.MockGitTagOperations{
-		TagExistsFn:          func(name string) (bool, error) { return false, nil },
-		CreateAnnotatedTagFn: func(name, message string) error { return fmt.Errorf("tag creation failed") },
+		TagExistsFn:          func(ctx context.Context, name string) (bool, error) { return false, nil },
+		CreateAnnotatedTagFn: func(ctx context.Context, name, message string) error { return fmt.Errorf("tag creation failed") },
 	}, &tagmanager.MockGitCommitOperations{
-		GetModifiedFilesFn: func() ([]string, error) { return []string{}, nil },
-		StageFilesFn:       func(files ...string) error { return nil },
-		CommitFn:           func(message string) error { return nil },
+		GetModifiedFilesFn: func(ctx context.Context) ([]string, error) { return []string{}, nil },
+		StageFilesFn:       func(ctx context.Context, files ...string) error { return nil },
+		CommitFn:           func(ctx context.Context, message string) error { return nil },
 	})
 
 	registry := plugins.NewPluginRegistry()
@@ -189,12 +190,12 @@ func TestCommitAndTagAfterBump_WithoutBumpedPath(t *testing.T) {
 		Prefix:     "v",
 		Annotate:   true,
 	}, &tagmanager.MockGitTagOperations{
-		TagExistsFn:          func(name string) (bool, error) { return false, nil },
-		CreateAnnotatedTagFn: func(name, message string) error { return nil },
+		TagExistsFn:          func(ctx context.Context, name string) (bool, error) { return false, nil },
+		CreateAnnotatedTagFn: func(ctx context.Context, name, message string) error { return nil },
 	}, &tagmanager.MockGitCommitOperations{
-		GetModifiedFilesFn: func() ([]string, error) { return []string{".version"}, nil },
-		StageFilesFn:       func(files ...string) error { return nil },
-		CommitFn:           func(message string) error { return nil },
+		GetModifiedFilesFn: func(ctx context.Context) ([]string, error) { return []string{".version"}, nil },
+		StageFilesFn:       func(ctx context.Context, files ...string) error { return nil },
+		CommitFn:           func(ctx context.Context, message string) error { return nil },
 	})
 
 	registry := plugins.NewPluginRegistry()
@@ -220,16 +221,16 @@ func TestCommitAndTagAfterBump_WithPush(t *testing.T) {
 		Annotate:   true,
 		Push:       true,
 	}, &tagmanager.MockGitTagOperations{
-		TagExistsFn:          func(name string) (bool, error) { return false, nil },
-		CreateAnnotatedTagFn: func(name, message string) error { return nil },
-		PushTagFn: func(name string) error {
+		TagExistsFn:          func(ctx context.Context, name string) (bool, error) { return false, nil },
+		CreateAnnotatedTagFn: func(ctx context.Context, name, message string) error { return nil },
+		PushTagFn: func(ctx context.Context, name string) error {
 			pushedTag = name
 			return nil
 		},
 	}, &tagmanager.MockGitCommitOperations{
-		GetModifiedFilesFn: func() ([]string, error) { return []string{}, nil },
-		StageFilesFn:       func(files ...string) error { return nil },
-		CommitFn:           func(message string) error { return nil },
+		GetModifiedFilesFn: func(ctx context.Context) ([]string, error) { return []string{}, nil },
+		StageFilesFn:       func(ctx context.Context, files ...string) error { return nil },
+		CommitFn:           func(ctx context.Context, message string) error { return nil },
 	})
 
 	registry := plugins.NewPluginRegistry()
@@ -257,12 +258,12 @@ func TestCommitAndTagAfterBump_CustomCommitMessageTemplate(t *testing.T) {
 		Annotate:              true,
 		CommitMessageTemplate: "release: bump to {version}",
 	}, &tagmanager.MockGitTagOperations{
-		TagExistsFn:          func(name string) (bool, error) { return false, nil },
-		CreateAnnotatedTagFn: func(name, message string) error { return nil },
+		TagExistsFn:          func(ctx context.Context, name string) (bool, error) { return false, nil },
+		CreateAnnotatedTagFn: func(ctx context.Context, name, message string) error { return nil },
 	}, &tagmanager.MockGitCommitOperations{
-		GetModifiedFilesFn: func() ([]string, error) { return []string{}, nil },
-		StageFilesFn:       func(files ...string) error { return nil },
-		CommitFn: func(message string) error {
+		GetModifiedFilesFn: func(ctx context.Context) ([]string, error) { return []string{}, nil },
+		StageFilesFn:       func(ctx context.Context, files ...string) error { return nil },
+		CommitFn: func(ctx context.Context, message string) error {
 			commitMsg = message
 			return nil
 		},

--- a/internal/commands/bump/bump_helpers_test.go
+++ b/internal/commands/bump/bump_helpers_test.go
@@ -3,6 +3,7 @@ package bump
 import (
 	"testing"
 
+	"github.com/indaco/sley/internal/plugins/tagmanager"
 	"github.com/indaco/sley/internal/semver"
 )
 
@@ -12,21 +13,22 @@ import (
 
 // mockTagManager implements tagmanager.TagManager for testing
 type mockTagManager struct {
-	validateErr error
-	createErr   error
+	validateErr       error
+	createErr         error
+	autoCreateEnabled bool
 }
 
-func (m *mockTagManager) Name() string                                    { return "mock-tag-manager" }
-func (m *mockTagManager) Description() string                             { return "mock tag manager" }
-func (m *mockTagManager) Version() string                                 { return "1.0.0" }
-func (m *mockTagManager) ValidateTagAvailable(v semver.SemVersion) error  { return m.validateErr }
-func (m *mockTagManager) CreateTag(v semver.SemVersion, msg string) error { return m.createErr }
-func (m *mockTagManager) FormatTagName(v semver.SemVersion) string        { return "v" + v.String() }
-func (m *mockTagManager) TagExists(v semver.SemVersion) (bool, error)     { return false, nil }
-func (m *mockTagManager) PushTag(v semver.SemVersion) error               { return nil }
-func (m *mockTagManager) DeleteTag(v semver.SemVersion) error             { return nil }
-func (m *mockTagManager) GetLatestTag() (semver.SemVersion, error)        { return semver.SemVersion{}, nil }
-func (m *mockTagManager) ListTags() ([]string, error)                     { return nil, nil }
+func (m *mockTagManager) Name() string                                        { return "mock-tag-manager" }
+func (m *mockTagManager) Description() string                                 { return "mock tag manager" }
+func (m *mockTagManager) Version() string                                     { return "1.0.0" }
+func (m *mockTagManager) ValidateTagAvailable(v semver.SemVersion) error      { return m.validateErr }
+func (m *mockTagManager) CreateTag(v semver.SemVersion, msg string) error     { return m.createErr }
+func (m *mockTagManager) FormatTagName(v semver.SemVersion) string            { return "v" + v.String() }
+func (m *mockTagManager) TagExists(v semver.SemVersion) (bool, error)         { return false, nil }
+func (m *mockTagManager) GetLatestTag() (semver.SemVersion, error)            { return semver.SemVersion{}, nil }
+func (m *mockTagManager) IsAutoCreateEnabled() bool                           { return m.autoCreateEnabled }
+func (m *mockTagManager) GetConfig() *tagmanager.Config                       { return tagmanager.DefaultConfig() }
+func (m *mockTagManager) CommitChanges(_ semver.SemVersion, _ []string) error { return nil }
 
 // mockVersionValidator implements versionvalidator.VersionValidator for testing
 type mockVersionValidator struct {
@@ -40,6 +42,7 @@ func (m *mockVersionValidator) Validate(newV, prevV semver.SemVersion, bumpType 
 	return m.validateErr
 }
 func (m *mockVersionValidator) ValidateSet(v semver.SemVersion) error { return nil }
+func (m *mockVersionValidator) IsEnabled() bool                       { return true }
 
 // mockReleaseGate implements releasegate.ReleaseGate for testing
 type mockReleaseGate struct {
@@ -52,6 +55,7 @@ func (m *mockReleaseGate) Version() string     { return "1.0.0" }
 func (m *mockReleaseGate) ValidateRelease(newV, prevV semver.SemVersion, bumpType string) error {
 	return m.validateErr
 }
+func (m *mockReleaseGate) IsEnabled() bool { return true }
 
 /* ------------------------------------------------------------------------- */
 /* HELPER FUNCTION TESTS                                                     */

--- a/internal/commands/bump/bump_plugins_test.go
+++ b/internal/commands/bump/bump_plugins_test.go
@@ -54,7 +54,7 @@ func TestValidateTagAvailable(t *testing.T) {
 
 	t.Run("mock tag manager returns validation error", func(t *testing.T) {
 		registry := plugins.NewPluginRegistry()
-		mock := &mockTagManager{validateErr: fmt.Errorf("tag exists")}
+		mock := &mockTagManager{validateErr: fmt.Errorf("tag exists"), autoCreateEnabled: true}
 		if err := registry.RegisterTagManager(mock); err != nil {
 			t.Fatalf("failed to register tag manager: %v", err)
 		}
@@ -654,7 +654,7 @@ func TestSingleModuleBump_ValidateTagAvailableFails(t *testing.T) {
 	// Create a tag manager that fails validation
 	cfg := &config.Config{Path: versionPath}
 	registry := plugins.NewPluginRegistry()
-	mock := &mockTagManager{validateErr: fmt.Errorf("tag already exists")}
+	mock := &mockTagManager{validateErr: fmt.Errorf("tag already exists"), autoCreateEnabled: true}
 	if err := registry.RegisterTagManager(mock); err != nil {
 		t.Fatalf("failed to register tag manager: %v", err)
 	}

--- a/internal/commands/bump/helpers.go
+++ b/internal/commands/bump/helpers.go
@@ -11,10 +11,6 @@ import (
 	"github.com/indaco/sley/internal/plugins"
 	"github.com/indaco/sley/internal/plugins/auditlog"
 	"github.com/indaco/sley/internal/plugins/changeloggenerator"
-	"github.com/indaco/sley/internal/plugins/dependencycheck"
-	"github.com/indaco/sley/internal/plugins/releasegate"
-	"github.com/indaco/sley/internal/plugins/tagmanager"
-	"github.com/indaco/sley/internal/plugins/versionvalidator"
 	"github.com/indaco/sley/internal/printer"
 	"github.com/indaco/sley/internal/semver"
 )
@@ -90,11 +86,8 @@ func validateTagAvailable(registry *plugins.PluginRegistry, version semver.SemVe
 		return nil
 	}
 
-	// Check if the plugin is enabled and auto-create is on
-	if plugin, ok := tm.(*tagmanager.TagManagerPlugin); ok {
-		if !plugin.IsAutoCreateEnabled() {
-			return nil
-		}
+	if !tm.IsAutoCreateEnabled() {
+		return nil
 	}
 
 	return tm.ValidateTagAvailable(version)
@@ -114,9 +107,7 @@ func commitAndTagAfterBump(registry *plugins.PluginRegistry, version semver.SemV
 		return nil
 	}
 
-	// Check if the plugin is enabled and auto-create is on
-	plugin, ok := tm.(*tagmanager.TagManagerPlugin)
-	if !ok || !plugin.IsAutoCreateEnabled() {
+	if !tm.IsAutoCreateEnabled() {
 		return nil
 	}
 
@@ -125,7 +116,7 @@ func commitAndTagAfterBump(registry *plugins.PluginRegistry, version semver.SemV
 	if bumpedPath != "" {
 		extraFiles = []string{bumpedPath}
 	}
-	if err := plugin.CommitChanges(version, extraFiles); err != nil {
+	if err := tm.CommitChanges(version, extraFiles); err != nil {
 		return fmt.Errorf("failed to commit release changes: %w", err)
 	}
 	printer.PrintSuccess(fmt.Sprintf("Committed release changes for %s", version.String()))
@@ -139,7 +130,7 @@ func commitAndTagAfterBump(registry *plugins.PluginRegistry, version semver.SemV
 	tagName := tm.FormatTagName(version)
 	printer.PrintSuccess(fmt.Sprintf("Created tag: %s", tagName))
 
-	if plugin.GetConfig().Push {
+	if tm.GetConfig().Push {
 		printer.PrintSuccess(fmt.Sprintf("Pushed tag: %s", tagName))
 	}
 
@@ -154,11 +145,8 @@ func validateVersionPolicy(registry *plugins.PluginRegistry, newVersion, previou
 		return nil
 	}
 
-	// Check if the plugin is enabled
-	if plugin, ok := vv.(*versionvalidator.VersionValidatorPlugin); ok {
-		if !plugin.IsEnabled() {
-			return nil
-		}
+	if !vv.IsEnabled() {
+		return nil
 	}
 
 	return vv.Validate(newVersion, previousVersion, bumpType)
@@ -172,11 +160,8 @@ func validateReleaseGate(registry *plugins.PluginRegistry, newVersion, previousV
 		return nil
 	}
 
-	// Check if the plugin is enabled
-	if plugin, ok := rg.(*releasegate.ReleaseGatePlugin); ok {
-		if !plugin.IsEnabled() {
-			return nil
-		}
+	if !rg.IsEnabled() {
+		return nil
 	}
 
 	return rg.ValidateRelease(newVersion, previousVersion, bumpType)
@@ -190,8 +175,7 @@ func validateDependencyConsistency(registry *plugins.PluginRegistry, version sem
 		return nil
 	}
 
-	plugin, ok := dc.(*dependencycheck.DependencyCheckerPlugin)
-	if !ok || !plugin.IsEnabled() {
+	if !dc.IsEnabled() {
 		return nil
 	}
 
@@ -202,7 +186,7 @@ func validateDependencyConsistency(registry *plugins.PluginRegistry, version sem
 
 	if len(inconsistencies) > 0 {
 		// If auto-sync is enabled, skip the error - inconsistencies will be fixed after the bump
-		if plugin.GetConfig().AutoSync {
+		if dc.GetConfig().AutoSync {
 			return nil
 		}
 
@@ -226,8 +210,7 @@ func generateChangelogAfterBump(registry *plugins.PluginRegistry, version, _ sem
 		return nil
 	}
 
-	plugin, ok := cg.(*changeloggenerator.ChangelogGeneratorPlugin)
-	if !ok || !plugin.IsEnabled() {
+	if !cg.IsEnabled() {
 		return nil
 	}
 
@@ -245,15 +228,15 @@ func generateChangelogAfterBump(registry *plugins.PluginRegistry, version, _ sem
 		return fmt.Errorf("failed to generate changelog: %w", err)
 	}
 
-	mode := plugin.GetConfig().Mode
-	switch mode {
+	cfg := cg.GetConfig()
+	switch cfg.Mode {
 	case "versioned":
-		printer.PrintSuccess(fmt.Sprintf("Generated changelog: %s/%s.md", plugin.GetConfig().ChangesDir, versionStr))
+		printer.PrintSuccess(fmt.Sprintf("Generated changelog: %s/%s.md", cfg.ChangesDir, versionStr))
 	case "unified":
-		printer.PrintSuccess(fmt.Sprintf("Updated changelog: %s", plugin.GetConfig().ChangelogPath))
+		printer.PrintSuccess(fmt.Sprintf("Updated changelog: %s", cfg.ChangelogPath))
 	case "both":
 		printer.PrintSuccess(fmt.Sprintf("Generated changelog: %s/%s.md and %s",
-			plugin.GetConfig().ChangesDir, versionStr, plugin.GetConfig().ChangelogPath))
+			cfg.ChangesDir, versionStr, cfg.ChangelogPath))
 	}
 
 	return nil
@@ -267,8 +250,7 @@ func recordAuditLogEntry(registry *plugins.PluginRegistry, version, previousVers
 		return nil
 	}
 
-	plugin, ok := al.(*auditlog.AuditLogPlugin)
-	if !ok || !plugin.IsEnabled() {
+	if !al.IsEnabled() {
 		return nil
 	}
 

--- a/internal/commands/depsync/sync.go
+++ b/internal/commands/depsync/sync.go
@@ -21,12 +21,11 @@ func SyncDependencies(registry *plugins.PluginRegistry, version semver.SemVersio
 		return nil
 	}
 
-	plugin, ok := dc.(*dependencycheck.DependencyCheckerPlugin)
-	if !ok || !plugin.IsEnabled() || !plugin.GetConfig().AutoSync {
+	if !dc.IsEnabled() || !dc.GetConfig().AutoSync {
 		return nil
 	}
 
-	files := plugin.GetConfig().Files
+	files := dc.GetConfig().Files
 	if len(files) == 0 {
 		return nil
 	}

--- a/internal/commands/tag/tagcmd.go
+++ b/internal/commands/tag/tagcmd.go
@@ -143,7 +143,7 @@ func (tc *TagCommand) runCreateCmd(ctx context.Context, cmd *cli.Command, cfg *c
 	prefix := tmConfig.Prefix
 	tagName := prefix + version.String()
 
-	exists, err := tc.gitOps.TagExists(tagName)
+	exists, err := tc.gitOps.TagExists(ctx, tagName)
 	if err != nil {
 		return fmt.Errorf("failed to check tag existence: %w", err)
 	}
@@ -157,7 +157,7 @@ func (tc *TagCommand) runCreateCmd(ctx context.Context, cmd *cli.Command, cfg *c
 		message = tagmanager.FormatMessage(tmConfig.MessageTemplate, data)
 	}
 
-	if err := tc.createTag(tagName, message, tmConfig); err != nil {
+	if err := tc.createTag(ctx, tagName, message, tmConfig); err != nil {
 		return err
 	}
 
@@ -165,7 +165,7 @@ func (tc *TagCommand) runCreateCmd(ctx context.Context, cmd *cli.Command, cfg *c
 
 	shouldPush := cmd.Bool("push") || tmConfig.Push
 	if shouldPush {
-		if err := tc.gitOps.PushTag(tagName); err != nil {
+		if err := tc.gitOps.PushTag(ctx, tagName); err != nil {
 			return fmt.Errorf("failed to push tag: %w", err)
 		}
 		printer.PrintSuccess(fmt.Sprintf("Pushed tag %s to remote", tagName))
@@ -175,18 +175,18 @@ func (tc *TagCommand) runCreateCmd(ctx context.Context, cmd *cli.Command, cfg *c
 }
 
 // createTag creates a tag based on the configuration.
-func (tc *TagCommand) createTag(tagName, message string, cfg *tagmanager.Config) error {
+func (tc *TagCommand) createTag(ctx context.Context, tagName, message string, cfg *tagmanager.Config) error {
 	switch {
 	case cfg.Sign:
-		if err := tc.gitOps.CreateSignedTag(tagName, message, cfg.SigningKey); err != nil {
+		if err := tc.gitOps.CreateSignedTag(ctx, tagName, message, cfg.SigningKey); err != nil {
 			return fmt.Errorf("failed to create signed tag: %w", err)
 		}
 	case cfg.Annotate:
-		if err := tc.gitOps.CreateAnnotatedTag(tagName, message); err != nil {
+		if err := tc.gitOps.CreateAnnotatedTag(ctx, tagName, message); err != nil {
 			return fmt.Errorf("failed to create annotated tag: %w", err)
 		}
 	default:
-		if err := tc.gitOps.CreateLightweightTag(tagName); err != nil {
+		if err := tc.gitOps.CreateLightweightTag(ctx, tagName); err != nil {
 			return fmt.Errorf("failed to create lightweight tag: %w", err)
 		}
 	}
@@ -194,11 +194,11 @@ func (tc *TagCommand) createTag(tagName, message string, cfg *tagmanager.Config)
 }
 
 // runListCmd lists existing version tags.
-func (tc *TagCommand) runListCmd(_ context.Context, cmd *cli.Command, cfg *config.Config) error {
+func (tc *TagCommand) runListCmd(ctx context.Context, cmd *cli.Command, cfg *config.Config) error {
 	prefix := getTagPrefix(cfg)
 	pattern := prefix + "*"
 
-	tags, err := tc.gitOps.ListTags(pattern)
+	tags, err := tc.gitOps.ListTags(ctx, pattern)
 	if err != nil {
 		return fmt.Errorf("failed to list tags: %w", err)
 	}
@@ -243,7 +243,7 @@ func (tc *TagCommand) runPushCmd(ctx context.Context, cmd *cli.Command, cfg *con
 		tagName = prefix + version.String()
 	}
 
-	exists, err := tc.gitOps.TagExists(tagName)
+	exists, err := tc.gitOps.TagExists(ctx, tagName)
 	if err != nil {
 		return fmt.Errorf("failed to check tag existence: %w", err)
 	}
@@ -251,7 +251,7 @@ func (tc *TagCommand) runPushCmd(ctx context.Context, cmd *cli.Command, cfg *con
 		return fmt.Errorf("tag %s does not exist locally", tagName)
 	}
 
-	if err := tc.gitOps.PushTag(tagName); err != nil {
+	if err := tc.gitOps.PushTag(ctx, tagName); err != nil {
 		return fmt.Errorf("failed to push tag: %w", err)
 	}
 
@@ -260,14 +260,14 @@ func (tc *TagCommand) runPushCmd(ctx context.Context, cmd *cli.Command, cfg *con
 }
 
 // runDeleteCmd deletes a git tag.
-func (tc *TagCommand) runDeleteCmd(_ context.Context, cmd *cli.Command, _ *config.Config) error {
+func (tc *TagCommand) runDeleteCmd(ctx context.Context, cmd *cli.Command, _ *config.Config) error {
 	if cmd.NArg() < 1 {
 		return cli.Exit("missing required tag name argument", 1)
 	}
 
 	tagName := cmd.Args().Get(0)
 
-	exists, err := tc.gitOps.TagExists(tagName)
+	exists, err := tc.gitOps.TagExists(ctx, tagName)
 	if err != nil {
 		return fmt.Errorf("failed to check tag existence: %w", err)
 	}
@@ -275,13 +275,13 @@ func (tc *TagCommand) runDeleteCmd(_ context.Context, cmd *cli.Command, _ *confi
 		return fmt.Errorf("tag %s does not exist locally", tagName)
 	}
 
-	if err := tc.gitOps.DeleteTag(tagName); err != nil {
+	if err := tc.gitOps.DeleteTag(ctx, tagName); err != nil {
 		return fmt.Errorf("failed to delete local tag: %w", err)
 	}
 	printer.PrintSuccess(fmt.Sprintf("Deleted local tag %s", tagName))
 
 	if cmd.Bool("remote") {
-		if err := tc.gitOps.DeleteRemoteTag(tagName); err != nil {
+		if err := tc.gitOps.DeleteRemoteTag(ctx, tagName); err != nil {
 			return fmt.Errorf("failed to delete remote tag: %w", err)
 		}
 		printer.PrintSuccess(fmt.Sprintf("Deleted remote tag %s", tagName))

--- a/internal/commands/tag/tagcmd_test.go
+++ b/internal/commands/tag/tagcmd_test.go
@@ -18,76 +18,76 @@ import (
 
 // mockGitTagOps is a mock implementation of core.GitTagOperations for testing.
 type mockGitTagOps struct {
-	tagExists          func(name string) (bool, error)
-	listTags           func(pattern string) ([]string, error)
-	pushTag            func(name string) error
-	deleteTag          func(name string) error
-	deleteRemoteTag    func(name string) error
-	createAnnotatedTag func(name, message string) error
-	createLightweight  func(name string) error
-	createSignedTag    func(name, message, keyID string) error
-	getLatestTag       func() (string, error)
+	tagExists          func(ctx context.Context, name string) (bool, error)
+	listTags           func(ctx context.Context, pattern string) ([]string, error)
+	pushTag            func(ctx context.Context, name string) error
+	deleteTag          func(ctx context.Context, name string) error
+	deleteRemoteTag    func(ctx context.Context, name string) error
+	createAnnotatedTag func(ctx context.Context, name, message string) error
+	createLightweight  func(ctx context.Context, name string) error
+	createSignedTag    func(ctx context.Context, name, message, keyID string) error
+	getLatestTag       func(ctx context.Context) (string, error)
 }
 
-func (m *mockGitTagOps) TagExists(name string) (bool, error) {
+func (m *mockGitTagOps) TagExists(ctx context.Context, name string) (bool, error) {
 	if m.tagExists != nil {
-		return m.tagExists(name)
+		return m.tagExists(ctx, name)
 	}
 	return false, nil
 }
 
-func (m *mockGitTagOps) ListTags(pattern string) ([]string, error) {
+func (m *mockGitTagOps) ListTags(ctx context.Context, pattern string) ([]string, error) {
 	if m.listTags != nil {
-		return m.listTags(pattern)
+		return m.listTags(ctx, pattern)
 	}
 	return []string{}, nil
 }
 
-func (m *mockGitTagOps) PushTag(name string) error {
+func (m *mockGitTagOps) PushTag(ctx context.Context, name string) error {
 	if m.pushTag != nil {
-		return m.pushTag(name)
+		return m.pushTag(ctx, name)
 	}
 	return nil
 }
 
-func (m *mockGitTagOps) DeleteTag(name string) error {
+func (m *mockGitTagOps) DeleteTag(ctx context.Context, name string) error {
 	if m.deleteTag != nil {
-		return m.deleteTag(name)
+		return m.deleteTag(ctx, name)
 	}
 	return nil
 }
 
-func (m *mockGitTagOps) DeleteRemoteTag(name string) error {
+func (m *mockGitTagOps) DeleteRemoteTag(ctx context.Context, name string) error {
 	if m.deleteRemoteTag != nil {
-		return m.deleteRemoteTag(name)
+		return m.deleteRemoteTag(ctx, name)
 	}
 	return nil
 }
 
-func (m *mockGitTagOps) CreateAnnotatedTag(name, message string) error {
+func (m *mockGitTagOps) CreateAnnotatedTag(ctx context.Context, name, message string) error {
 	if m.createAnnotatedTag != nil {
-		return m.createAnnotatedTag(name, message)
+		return m.createAnnotatedTag(ctx, name, message)
 	}
 	return nil
 }
 
-func (m *mockGitTagOps) CreateLightweightTag(name string) error {
+func (m *mockGitTagOps) CreateLightweightTag(ctx context.Context, name string) error {
 	if m.createLightweight != nil {
-		return m.createLightweight(name)
+		return m.createLightweight(ctx, name)
 	}
 	return nil
 }
 
-func (m *mockGitTagOps) CreateSignedTag(name, message, keyID string) error {
+func (m *mockGitTagOps) CreateSignedTag(ctx context.Context, name, message, keyID string) error {
 	if m.createSignedTag != nil {
-		return m.createSignedTag(name, message, keyID)
+		return m.createSignedTag(ctx, name, message, keyID)
 	}
 	return nil
 }
 
-func (m *mockGitTagOps) GetLatestTag() (string, error) {
+func (m *mockGitTagOps) GetLatestTag(ctx context.Context) (string, error) {
 	if m.getLatestTag != nil {
-		return m.getLatestTag()
+		return m.getLatestTag(ctx)
 	}
 	return "", nil
 }
@@ -396,7 +396,7 @@ func TestRunCreateCmd_TagAlreadyExists(t *testing.T) {
 	}
 
 	mockOps := &mockGitTagOps{
-		tagExists: func(name string) (bool, error) {
+		tagExists: func(ctx context.Context, name string) (bool, error) {
 			return true, nil
 		},
 	}
@@ -432,10 +432,10 @@ func TestRunCreateCmd_Success(t *testing.T) {
 
 	var createdTag string
 	mockOps := &mockGitTagOps{
-		tagExists: func(name string) (bool, error) {
+		tagExists: func(ctx context.Context, name string) (bool, error) {
 			return false, nil
 		},
-		createAnnotatedTag: func(name, message string) error {
+		createAnnotatedTag: func(ctx context.Context, name, message string) error {
 			createdTag = name
 			return nil
 		},
@@ -465,7 +465,7 @@ func TestRunCreateCmd_Success(t *testing.T) {
 
 func TestRunListCmd(t *testing.T) {
 	mockOps := &mockGitTagOps{
-		listTags: func(pattern string) ([]string, error) {
+		listTags: func(ctx context.Context, pattern string) ([]string, error) {
 			return []string{"v1.0.0", "v2.0.0", "v1.5.0"}, nil
 		},
 	}
@@ -494,10 +494,10 @@ func TestRunListCmd(t *testing.T) {
 func TestRunPushCmd_TagExists(t *testing.T) {
 	var pushedTag string
 	mockOps := &mockGitTagOps{
-		tagExists: func(name string) (bool, error) {
+		tagExists: func(ctx context.Context, name string) (bool, error) {
 			return true, nil
 		},
-		pushTag: func(name string) error {
+		pushTag: func(ctx context.Context, name string) error {
 			pushedTag = name
 			return nil
 		},
@@ -527,7 +527,7 @@ func TestRunPushCmd_TagExists(t *testing.T) {
 
 func TestRunPushCmd_TagNotExists(t *testing.T) {
 	mockOps := &mockGitTagOps{
-		tagExists: func(name string) (bool, error) {
+		tagExists: func(ctx context.Context, name string) (bool, error) {
 			return false, nil
 		},
 	}
@@ -554,10 +554,10 @@ func TestRunPushCmd_TagNotExists(t *testing.T) {
 func TestRunDeleteCmd_TagExists(t *testing.T) {
 	var deletedTag string
 	mockOps := &mockGitTagOps{
-		tagExists: func(name string) (bool, error) {
+		tagExists: func(ctx context.Context, name string) (bool, error) {
 			return true, nil
 		},
-		deleteTag: func(name string) error {
+		deleteTag: func(ctx context.Context, name string) error {
 			deletedTag = name
 			return nil
 		},
@@ -590,7 +590,7 @@ func TestRunDeleteCmd_TagExists(t *testing.T) {
 
 func TestRunDeleteCmd_TagNotExists(t *testing.T) {
 	mockOps := &mockGitTagOps{
-		tagExists: func(name string) (bool, error) {
+		tagExists: func(ctx context.Context, name string) (bool, error) {
 			return false, nil
 		},
 	}
@@ -620,14 +620,14 @@ func TestRunDeleteCmd_TagNotExists(t *testing.T) {
 func TestRunDeleteCmd_WithRemote(t *testing.T) {
 	var deletedLocal, deletedRemote string
 	mockOps := &mockGitTagOps{
-		tagExists: func(name string) (bool, error) {
+		tagExists: func(ctx context.Context, name string) (bool, error) {
 			return true, nil
 		},
-		deleteTag: func(name string) error {
+		deleteTag: func(ctx context.Context, name string) error {
 			deletedLocal = name
 			return nil
 		},
-		deleteRemoteTag: func(name string) error {
+		deleteRemoteTag: func(ctx context.Context, name string) error {
 			deletedRemote = name
 			return nil
 		},
@@ -841,7 +841,7 @@ func TestRunCommand(t *testing.T) {
 func TestCreateTag_Signed(t *testing.T) {
 	var signedTag, signedMessage, signedKeyID string
 	mockOps := &mockGitTagOps{
-		createSignedTag: func(name, message, keyID string) error {
+		createSignedTag: func(ctx context.Context, name, message, keyID string) error {
 			signedTag = name
 			signedMessage = message
 			signedKeyID = keyID
@@ -855,7 +855,7 @@ func TestCreateTag_Signed(t *testing.T) {
 		SigningKey: "ABC123",
 	}
 
-	err := tc.createTag("v1.0.0", "Release 1.0.0", cfg)
+	err := tc.createTag(context.Background(), "v1.0.0", "Release 1.0.0", cfg)
 	if err != nil {
 		t.Errorf("createTag() unexpected error: %v", err)
 	}
@@ -873,7 +873,7 @@ func TestCreateTag_Signed(t *testing.T) {
 func TestCreateTag_Lightweight(t *testing.T) {
 	var lightweightTag string
 	mockOps := &mockGitTagOps{
-		createLightweight: func(name string) error {
+		createLightweight: func(ctx context.Context, name string) error {
 			lightweightTag = name
 			return nil
 		},
@@ -885,7 +885,7 @@ func TestCreateTag_Lightweight(t *testing.T) {
 		Annotate: false,
 	}
 
-	err := tc.createTag("v1.0.0", "ignored message", cfg)
+	err := tc.createTag(context.Background(), "v1.0.0", "ignored message", cfg)
 	if err != nil {
 		t.Errorf("createTag() unexpected error: %v", err)
 	}
@@ -896,7 +896,7 @@ func TestCreateTag_Lightweight(t *testing.T) {
 
 func TestCreateTag_SignedError(t *testing.T) {
 	mockOps := &mockGitTagOps{
-		createSignedTag: func(name, message, keyID string) error {
+		createSignedTag: func(ctx context.Context, name, message, keyID string) error {
 			return fmt.Errorf("gpg signing failed")
 		},
 	}
@@ -904,7 +904,7 @@ func TestCreateTag_SignedError(t *testing.T) {
 
 	cfg := &tagmanager.Config{Sign: true}
 
-	err := tc.createTag("v1.0.0", "Release", cfg)
+	err := tc.createTag(context.Background(), "v1.0.0", "Release", cfg)
 	if err == nil {
 		t.Error("createTag() expected error for signed tag failure")
 	}
@@ -912,7 +912,7 @@ func TestCreateTag_SignedError(t *testing.T) {
 
 func TestCreateTag_AnnotatedError(t *testing.T) {
 	mockOps := &mockGitTagOps{
-		createAnnotatedTag: func(name, message string) error {
+		createAnnotatedTag: func(ctx context.Context, name, message string) error {
 			return fmt.Errorf("annotated tag failed")
 		},
 	}
@@ -920,7 +920,7 @@ func TestCreateTag_AnnotatedError(t *testing.T) {
 
 	cfg := &tagmanager.Config{Sign: false, Annotate: true}
 
-	err := tc.createTag("v1.0.0", "Release", cfg)
+	err := tc.createTag(context.Background(), "v1.0.0", "Release", cfg)
 	if err == nil {
 		t.Error("createTag() expected error for annotated tag failure")
 	}
@@ -928,7 +928,7 @@ func TestCreateTag_AnnotatedError(t *testing.T) {
 
 func TestCreateTag_LightweightError(t *testing.T) {
 	mockOps := &mockGitTagOps{
-		createLightweight: func(name string) error {
+		createLightweight: func(ctx context.Context, name string) error {
 			return fmt.Errorf("lightweight tag failed")
 		},
 	}
@@ -936,7 +936,7 @@ func TestCreateTag_LightweightError(t *testing.T) {
 
 	cfg := &tagmanager.Config{Sign: false, Annotate: false}
 
-	err := tc.createTag("v1.0.0", "ignored", cfg)
+	err := tc.createTag(context.Background(), "v1.0.0", "ignored", cfg)
 	if err == nil {
 		t.Error("createTag() expected error for lightweight tag failure")
 	}
@@ -944,7 +944,7 @@ func TestCreateTag_LightweightError(t *testing.T) {
 
 func TestRunListCmd_Empty(t *testing.T) {
 	mockOps := &mockGitTagOps{
-		listTags: func(pattern string) ([]string, error) {
+		listTags: func(ctx context.Context, pattern string) ([]string, error) {
 			return []string{}, nil
 		},
 	}
@@ -966,7 +966,7 @@ func TestRunListCmd_Empty(t *testing.T) {
 
 func TestRunListCmd_Error(t *testing.T) {
 	mockOps := &mockGitTagOps{
-		listTags: func(pattern string) ([]string, error) {
+		listTags: func(ctx context.Context, pattern string) ([]string, error) {
 			return nil, fmt.Errorf("git error")
 		},
 	}
@@ -986,7 +986,7 @@ func TestRunListCmd_Error(t *testing.T) {
 
 func TestRunListCmd_WithLimit(t *testing.T) {
 	mockOps := &mockGitTagOps{
-		listTags: func(pattern string) ([]string, error) {
+		listTags: func(ctx context.Context, pattern string) ([]string, error) {
 			return []string{"v3.0.0", "v2.0.0", "v1.0.0"}, nil
 		},
 	}
@@ -1022,10 +1022,10 @@ func TestRunPushCmd_NoArg(t *testing.T) {
 
 	var pushedTag string
 	mockOps := &mockGitTagOps{
-		tagExists: func(name string) (bool, error) {
+		tagExists: func(ctx context.Context, name string) (bool, error) {
 			return true, nil
 		},
-		pushTag: func(name string) error {
+		pushTag: func(ctx context.Context, name string) error {
 			pushedTag = name
 			return nil
 		},
@@ -1087,7 +1087,7 @@ func TestRunPushCmd_VersionReadError(t *testing.T) {
 
 func TestRunPushCmd_TagExistsError(t *testing.T) {
 	mockOps := &mockGitTagOps{
-		tagExists: func(name string) (bool, error) {
+		tagExists: func(ctx context.Context, name string) (bool, error) {
 			return false, fmt.Errorf("git error")
 		},
 	}
@@ -1113,10 +1113,10 @@ func TestRunPushCmd_TagExistsError(t *testing.T) {
 
 func TestRunPushCmd_PushError(t *testing.T) {
 	mockOps := &mockGitTagOps{
-		tagExists: func(name string) (bool, error) {
+		tagExists: func(ctx context.Context, name string) (bool, error) {
 			return true, nil
 		},
-		pushTag: func(name string) error {
+		pushTag: func(ctx context.Context, name string) error {
 			return fmt.Errorf("push failed")
 		},
 	}
@@ -1149,14 +1149,14 @@ func TestRunCreateCmd_WithPush(t *testing.T) {
 
 	var createdTag, pushedTag string
 	mockOps := &mockGitTagOps{
-		tagExists: func(name string) (bool, error) {
+		tagExists: func(ctx context.Context, name string) (bool, error) {
 			return false, nil
 		},
-		createAnnotatedTag: func(name, message string) error {
+		createAnnotatedTag: func(ctx context.Context, name, message string) error {
 			createdTag = name
 			return nil
 		},
-		pushTag: func(name string) error {
+		pushTag: func(ctx context.Context, name string) error {
 			pushedTag = name
 			return nil
 		},
@@ -1202,13 +1202,13 @@ func TestRunCreateCmd_PushError(t *testing.T) {
 	}
 
 	mockOps := &mockGitTagOps{
-		tagExists: func(name string) (bool, error) {
+		tagExists: func(ctx context.Context, name string) (bool, error) {
 			return false, nil
 		},
-		createAnnotatedTag: func(name, message string) error {
+		createAnnotatedTag: func(ctx context.Context, name, message string) error {
 			return nil
 		},
-		pushTag: func(name string) error {
+		pushTag: func(ctx context.Context, name string) error {
 			return fmt.Errorf("push failed")
 		},
 	}
@@ -1247,7 +1247,7 @@ func TestRunCreateCmd_TagExistsError(t *testing.T) {
 	}
 
 	mockOps := &mockGitTagOps{
-		tagExists: func(name string) (bool, error) {
+		tagExists: func(ctx context.Context, name string) (bool, error) {
 			return false, fmt.Errorf("git error")
 		},
 	}
@@ -1277,10 +1277,10 @@ func TestRunCreateCmd_CreateTagError(t *testing.T) {
 	}
 
 	mockOps := &mockGitTagOps{
-		tagExists: func(name string) (bool, error) {
+		tagExists: func(ctx context.Context, name string) (bool, error) {
 			return false, nil
 		},
-		createAnnotatedTag: func(name, message string) error {
+		createAnnotatedTag: func(ctx context.Context, name, message string) error {
 			return fmt.Errorf("create tag failed")
 		},
 	}
@@ -1336,7 +1336,7 @@ func TestRunDeleteCmd_MissingArg(t *testing.T) {
 
 func TestRunDeleteCmd_TagExistsError(t *testing.T) {
 	mockOps := &mockGitTagOps{
-		tagExists: func(name string) (bool, error) {
+		tagExists: func(ctx context.Context, name string) (bool, error) {
 			return false, fmt.Errorf("git error")
 		},
 	}
@@ -1365,10 +1365,10 @@ func TestRunDeleteCmd_TagExistsError(t *testing.T) {
 
 func TestRunDeleteCmd_DeleteLocalError(t *testing.T) {
 	mockOps := &mockGitTagOps{
-		tagExists: func(name string) (bool, error) {
+		tagExists: func(ctx context.Context, name string) (bool, error) {
 			return true, nil
 		},
-		deleteTag: func(name string) error {
+		deleteTag: func(ctx context.Context, name string) error {
 			return fmt.Errorf("delete failed")
 		},
 	}
@@ -1397,13 +1397,13 @@ func TestRunDeleteCmd_DeleteLocalError(t *testing.T) {
 
 func TestRunDeleteCmd_DeleteRemoteError(t *testing.T) {
 	mockOps := &mockGitTagOps{
-		tagExists: func(name string) (bool, error) {
+		tagExists: func(ctx context.Context, name string) (bool, error) {
 			return true, nil
 		},
-		deleteTag: func(name string) error {
+		deleteTag: func(ctx context.Context, name string) error {
 			return nil
 		},
-		deleteRemoteTag: func(name string) error {
+		deleteRemoteTag: func(ctx context.Context, name string) error {
 			return fmt.Errorf("remote delete failed")
 		},
 	}
@@ -1631,10 +1631,10 @@ func TestCLI_TagCreate_MultiModule(t *testing.T) {
 
 	var createdTag string
 	mockOps := &mockGitTagOps{
-		tagExists: func(name string) (bool, error) {
+		tagExists: func(ctx context.Context, name string) (bool, error) {
 			return false, nil
 		},
-		createAnnotatedTag: func(name, message string) error {
+		createAnnotatedTag: func(ctx context.Context, name, message string) error {
 			createdTag = name
 			return nil
 		},
@@ -1718,10 +1718,10 @@ func TestCLI_TagPush_MultiModule_NoArg(t *testing.T) {
 
 	var pushedTag string
 	mockOps := &mockGitTagOps{
-		tagExists: func(name string) (bool, error) {
+		tagExists: func(ctx context.Context, name string) (bool, error) {
 			return true, nil
 		},
-		pushTag: func(name string) error {
+		pushTag: func(ctx context.Context, name string) error {
 			pushedTag = name
 			return nil
 		},

--- a/internal/core/interfaces.go
+++ b/internal/core/interfaces.go
@@ -105,42 +105,42 @@ type MarshalUnmarshaler interface {
 // GitTagOperations abstracts git tag operations for testability.
 type GitTagOperations interface {
 	// CreateAnnotatedTag creates an annotated git tag with the given name and message.
-	CreateAnnotatedTag(name, message string) error
+	CreateAnnotatedTag(ctx context.Context, name, message string) error
 
 	// CreateLightweightTag creates a lightweight git tag with the given name.
-	CreateLightweightTag(name string) error
+	CreateLightweightTag(ctx context.Context, name string) error
 
 	// CreateSignedTag creates a GPG-signed git tag with the given name, message, and optional key ID.
 	// If keyID is empty, git uses the default signing key from user.signingkey config.
-	CreateSignedTag(name, message, keyID string) error
+	CreateSignedTag(ctx context.Context, name, message, keyID string) error
 
 	// TagExists checks if a git tag with the given name exists.
-	TagExists(name string) (bool, error)
+	TagExists(ctx context.Context, name string) (bool, error)
 
 	// GetLatestTag returns the most recent semver tag from git.
-	GetLatestTag() (string, error)
+	GetLatestTag(ctx context.Context) (string, error)
 
 	// PushTag pushes a specific tag to the remote.
-	PushTag(name string) error
+	PushTag(ctx context.Context, name string) error
 
 	// ListTags returns all git tags matching a pattern.
-	ListTags(pattern string) ([]string, error)
+	ListTags(ctx context.Context, pattern string) ([]string, error)
 
 	// DeleteTag deletes a local git tag.
-	DeleteTag(name string) error
+	DeleteTag(ctx context.Context, name string) error
 
 	// DeleteRemoteTag deletes a tag from the remote repository.
-	DeleteRemoteTag(name string) error
+	DeleteRemoteTag(ctx context.Context, name string) error
 }
 
 // GitCommitOperations provides git staging and commit capabilities.
 type GitCommitOperations interface {
 	// StageFiles stages the specified files for commit (git add).
-	StageFiles(files ...string) error
+	StageFiles(ctx context.Context, files ...string) error
 	// Commit creates a commit with the given message (git commit -m).
-	Commit(message string) error
+	Commit(ctx context.Context, message string) error
 	// GetModifiedFiles returns files with uncommitted changes (git status --porcelain).
-	GetModifiedFiles() ([]string, error)
+	GetModifiedFiles(ctx context.Context) ([]string, error)
 }
 
 // GitCommitReader reads git commit information.

--- a/internal/core/mocks.go
+++ b/internal/core/mocks.go
@@ -375,10 +375,11 @@ func NewMockGitTagOperations() *MockGitTagOperations {
 	return &MockGitTagOperations{
 		CreatedTags: make([]string, 0),
 		PushedTags:  make([]string, 0),
+		DeletedTags: make([]string, 0),
 	}
 }
 
-func (m *MockGitTagOperations) CreateAnnotatedTag(name, message string) error {
+func (m *MockGitTagOperations) CreateAnnotatedTag(ctx context.Context, name, message string) error {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	if m.CreateAnnotatedTagErr != nil {
@@ -388,7 +389,7 @@ func (m *MockGitTagOperations) CreateAnnotatedTag(name, message string) error {
 	return nil
 }
 
-func (m *MockGitTagOperations) CreateLightweightTag(name string) error {
+func (m *MockGitTagOperations) CreateLightweightTag(ctx context.Context, name string) error {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	if m.CreateLightweightTagErr != nil {
@@ -398,35 +399,7 @@ func (m *MockGitTagOperations) CreateLightweightTag(name string) error {
 	return nil
 }
 
-func (m *MockGitTagOperations) TagExists(name string) (bool, error) {
-	m.mu.Lock()
-	defer m.mu.Unlock()
-	if m.TagExistsErr != nil {
-		return false, m.TagExistsErr
-	}
-	return m.TagExistsResult, nil
-}
-
-func (m *MockGitTagOperations) GetLatestTag() (string, error) {
-	m.mu.Lock()
-	defer m.mu.Unlock()
-	if m.GetLatestTagErr != nil {
-		return "", m.GetLatestTagErr
-	}
-	return m.GetLatestTagName, nil
-}
-
-func (m *MockGitTagOperations) PushTag(name string) error {
-	m.mu.Lock()
-	defer m.mu.Unlock()
-	if m.PushTagErr != nil {
-		return m.PushTagErr
-	}
-	m.PushedTags = append(m.PushedTags, name)
-	return nil
-}
-
-func (m *MockGitTagOperations) CreateSignedTag(name, message, keyID string) error {
+func (m *MockGitTagOperations) CreateSignedTag(ctx context.Context, name, message, keyID string) error {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	if m.CreateSignedTagErr != nil {
@@ -436,7 +409,35 @@ func (m *MockGitTagOperations) CreateSignedTag(name, message, keyID string) erro
 	return nil
 }
 
-func (m *MockGitTagOperations) ListTags(pattern string) ([]string, error) {
+func (m *MockGitTagOperations) TagExists(ctx context.Context, name string) (bool, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if m.TagExistsErr != nil {
+		return false, m.TagExistsErr
+	}
+	return m.TagExistsResult, nil
+}
+
+func (m *MockGitTagOperations) GetLatestTag(ctx context.Context) (string, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if m.GetLatestTagErr != nil {
+		return "", m.GetLatestTagErr
+	}
+	return m.GetLatestTagName, nil
+}
+
+func (m *MockGitTagOperations) PushTag(ctx context.Context, name string) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if m.PushTagErr != nil {
+		return m.PushTagErr
+	}
+	m.PushedTags = append(m.PushedTags, name)
+	return nil
+}
+
+func (m *MockGitTagOperations) ListTags(ctx context.Context, pattern string) ([]string, error) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	m.ListTagsCalled = true
@@ -446,7 +447,7 @@ func (m *MockGitTagOperations) ListTags(pattern string) ([]string, error) {
 	return m.ListTagsResult, nil
 }
 
-func (m *MockGitTagOperations) DeleteTag(name string) error {
+func (m *MockGitTagOperations) DeleteTag(ctx context.Context, name string) error {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	if m.DeleteTagErr != nil {
@@ -456,7 +457,7 @@ func (m *MockGitTagOperations) DeleteTag(name string) error {
 	return nil
 }
 
-func (m *MockGitTagOperations) DeleteRemoteTag(name string) error {
+func (m *MockGitTagOperations) DeleteRemoteTag(ctx context.Context, name string) error {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	if m.DeleteRemoteTagErr != nil {
@@ -492,7 +493,7 @@ func NewMockGitCommitOperations() *MockGitCommitOperations {
 	}
 }
 
-func (m *MockGitCommitOperations) StageFiles(files ...string) error {
+func (m *MockGitCommitOperations) StageFiles(ctx context.Context, files ...string) error {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	if m.StageFilesErr != nil {
@@ -502,7 +503,7 @@ func (m *MockGitCommitOperations) StageFiles(files ...string) error {
 	return nil
 }
 
-func (m *MockGitCommitOperations) Commit(message string) error {
+func (m *MockGitCommitOperations) Commit(ctx context.Context, message string) error {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	if m.CommitErr != nil {
@@ -512,7 +513,7 @@ func (m *MockGitCommitOperations) Commit(message string) error {
 	return nil
 }
 
-func (m *MockGitCommitOperations) GetModifiedFiles() ([]string, error) {
+func (m *MockGitCommitOperations) GetModifiedFiles(ctx context.Context) ([]string, error) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	m.GetModifiedCalls++

--- a/internal/core/mocks_git_test.go
+++ b/internal/core/mocks_git_test.go
@@ -86,8 +86,9 @@ func TestMockGitClient_CloneError(t *testing.T) {
 
 func TestMockGitTagOperations_CreateAnnotatedTag(t *testing.T) {
 	mock := NewMockGitTagOperations()
+	ctx := context.Background()
 
-	err := mock.CreateAnnotatedTag("v1.0.0", "Release 1.0.0")
+	err := mock.CreateAnnotatedTag(ctx, "v1.0.0", "Release 1.0.0")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -97,7 +98,7 @@ func TestMockGitTagOperations_CreateAnnotatedTag(t *testing.T) {
 
 	// Test with error
 	mock.CreateAnnotatedTagErr = errors.New("tag error")
-	err = mock.CreateAnnotatedTag("v1.0.1", "msg")
+	err = mock.CreateAnnotatedTag(ctx, "v1.0.1", "msg")
 	if err == nil || err.Error() != "tag error" {
 		t.Errorf("expected 'tag error', got %v", err)
 	}
@@ -105,8 +106,9 @@ func TestMockGitTagOperations_CreateAnnotatedTag(t *testing.T) {
 
 func TestMockGitTagOperations_CreateLightweightTag(t *testing.T) {
 	mock := NewMockGitTagOperations()
+	ctx := context.Background()
 
-	err := mock.CreateLightweightTag("v2.0.0")
+	err := mock.CreateLightweightTag(ctx, "v2.0.0")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -116,17 +118,38 @@ func TestMockGitTagOperations_CreateLightweightTag(t *testing.T) {
 
 	// Test with error
 	mock.CreateLightweightTagErr = errors.New("lightweight tag error")
-	err = mock.CreateLightweightTag("v2.0.1")
+	err = mock.CreateLightweightTag(ctx, "v2.0.1")
 	if err == nil || err.Error() != "lightweight tag error" {
 		t.Errorf("expected 'lightweight tag error', got %v", err)
 	}
 }
 
+func TestMockGitTagOperations_CreateSignedTag(t *testing.T) {
+	mock := NewMockGitTagOperations()
+	ctx := context.Background()
+
+	err := mock.CreateSignedTag(ctx, "v1.0.0", "Release 1.0.0", "ABCD1234")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(mock.CreatedTags) != 1 || mock.CreatedTags[0] != "v1.0.0" {
+		t.Errorf("expected tag v1.0.0 in CreatedTags, got %v", mock.CreatedTags)
+	}
+
+	// Test with error
+	mock.CreateSignedTagErr = errors.New("signed tag error")
+	err = mock.CreateSignedTag(ctx, "v1.0.1", "msg", "KEY123")
+	if err == nil || err.Error() != "signed tag error" {
+		t.Errorf("expected 'signed tag error', got %v", err)
+	}
+}
+
 func TestMockGitTagOperations_TagExists(t *testing.T) {
 	mock := NewMockGitTagOperations()
+	ctx := context.Background()
 
 	mock.TagExistsResult = true
-	exists, err := mock.TagExists("v1.0.0")
+	exists, err := mock.TagExists(ctx, "v1.0.0")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -135,7 +158,7 @@ func TestMockGitTagOperations_TagExists(t *testing.T) {
 	}
 
 	mock.TagExistsResult = false
-	exists, err = mock.TagExists("v9.9.9")
+	exists, err = mock.TagExists(ctx, "v9.9.9")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -145,7 +168,7 @@ func TestMockGitTagOperations_TagExists(t *testing.T) {
 
 	// Test with error
 	mock.TagExistsErr = errors.New("tag exists error")
-	_, err = mock.TagExists("v1.0.0")
+	_, err = mock.TagExists(ctx, "v1.0.0")
 	if err == nil || err.Error() != "tag exists error" {
 		t.Errorf("expected 'tag exists error', got %v", err)
 	}
@@ -153,9 +176,10 @@ func TestMockGitTagOperations_TagExists(t *testing.T) {
 
 func TestMockGitTagOperations_GetLatestTag(t *testing.T) {
 	mock := NewMockGitTagOperations()
+	ctx := context.Background()
 
 	mock.GetLatestTagName = "v3.0.0"
-	tag, err := mock.GetLatestTag()
+	tag, err := mock.GetLatestTag(ctx)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -165,7 +189,7 @@ func TestMockGitTagOperations_GetLatestTag(t *testing.T) {
 
 	// Test with error
 	mock.GetLatestTagErr = errors.New("no tags")
-	_, err = mock.GetLatestTag()
+	_, err = mock.GetLatestTag(ctx)
 	if err == nil || err.Error() != "no tags" {
 		t.Errorf("expected 'no tags', got %v", err)
 	}
@@ -173,8 +197,9 @@ func TestMockGitTagOperations_GetLatestTag(t *testing.T) {
 
 func TestMockGitTagOperations_PushTag(t *testing.T) {
 	mock := NewMockGitTagOperations()
+	ctx := context.Background()
 
-	err := mock.PushTag("v1.0.0")
+	err := mock.PushTag(ctx, "v1.0.0")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -184,9 +209,67 @@ func TestMockGitTagOperations_PushTag(t *testing.T) {
 
 	// Test with error
 	mock.PushTagErr = errors.New("push error")
-	err = mock.PushTag("v1.0.1")
+	err = mock.PushTag(ctx, "v1.0.1")
 	if err == nil || err.Error() != "push error" {
 		t.Errorf("expected 'push error', got %v", err)
+	}
+}
+
+func TestMockGitTagOperations_ListTags(t *testing.T) {
+	mock := NewMockGitTagOperations()
+	ctx := context.Background()
+
+	mock.ListTagsResult = []string{"v1.0.0", "v1.1.0", "v2.0.0"}
+	tags, err := mock.ListTags(ctx, "v*")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(tags) != 3 {
+		t.Errorf("expected 3 tags, got %d", len(tags))
+	}
+
+	// Test with error
+	mock.ListTagsErr = errors.New("list tags error")
+	_, err = mock.ListTags(ctx, "v*")
+	if err == nil || err.Error() != "list tags error" {
+		t.Errorf("expected 'list tags error', got %v", err)
+	}
+}
+
+func TestMockGitTagOperations_DeleteTag(t *testing.T) {
+	mock := NewMockGitTagOperations()
+	ctx := context.Background()
+
+	err := mock.DeleteTag(ctx, "v1.0.0")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(mock.DeletedTags) != 1 || mock.DeletedTags[0] != "v1.0.0" {
+		t.Errorf("expected deleted tag v1.0.0, got %v", mock.DeletedTags)
+	}
+
+	// Test with error
+	mock.DeleteTagErr = errors.New("delete tag error")
+	err = mock.DeleteTag(ctx, "v1.0.1")
+	if err == nil || err.Error() != "delete tag error" {
+		t.Errorf("expected 'delete tag error', got %v", err)
+	}
+}
+
+func TestMockGitTagOperations_DeleteRemoteTag(t *testing.T) {
+	mock := NewMockGitTagOperations()
+	ctx := context.Background()
+
+	err := mock.DeleteRemoteTag(ctx, "v1.0.0")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// Test with error
+	mock.DeleteRemoteTagErr = errors.New("delete remote tag error")
+	err = mock.DeleteRemoteTag(ctx, "v1.0.1")
+	if err == nil || err.Error() != "delete remote tag error" {
+		t.Errorf("expected 'delete remote tag error', got %v", err)
 	}
 }
 

--- a/internal/plugins/registry_test.go
+++ b/internal/plugins/registry_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/indaco/sley/internal/plugins/changelogparser"
 	"github.com/indaco/sley/internal/plugins/dependencycheck"
 	"github.com/indaco/sley/internal/plugins/releasegate"
+	"github.com/indaco/sley/internal/plugins/tagmanager"
 	"github.com/indaco/sley/internal/plugins/versionvalidator"
 	"github.com/indaco/sley/internal/semver"
 )
@@ -36,10 +37,10 @@ func (m *mockTagManager) GetLatestTag() (semver.SemVersion, error) {
 func (m *mockTagManager) ValidateTagAvailable(version semver.SemVersion) error {
 	return nil
 }
-func (m *mockTagManager) FormatTagName(version semver.SemVersion) string { return "v1.0.0" }
-func (m *mockTagManager) PushTag(version semver.SemVersion) error        { return nil }
-func (m *mockTagManager) DeleteTag(version semver.SemVersion) error      { return nil }
-func (m *mockTagManager) ListTags() ([]string, error)                    { return nil, nil }
+func (m *mockTagManager) FormatTagName(version semver.SemVersion) string      { return "v1.0.0" }
+func (m *mockTagManager) IsAutoCreateEnabled() bool                           { return false }
+func (m *mockTagManager) GetConfig() *tagmanager.Config                       { return tagmanager.DefaultConfig() }
+func (m *mockTagManager) CommitChanges(_ semver.SemVersion, _ []string) error { return nil }
 
 func TestPluginRegistry_CommitParser(t *testing.T) {
 	t.Run("register and get", func(t *testing.T) {

--- a/internal/plugins/releasegate/releasegate.go
+++ b/internal/plugins/releasegate/releasegate.go
@@ -14,6 +14,7 @@ type ReleaseGate interface {
 	Description() string
 	Version() string
 	ValidateRelease(newVersion, previousVersion semver.SemVersion, bumpType string) error
+	IsEnabled() bool
 }
 
 // ReleaseGatePlugin implements the ReleaseGate interface.

--- a/internal/plugins/tagmanager/git.go
+++ b/internal/plugins/tagmanager/git.go
@@ -2,6 +2,7 @@ package tagmanager
 
 import (
 	"bytes"
+	"context"
 	"fmt"
 	"os/exec"
 	"strings"
@@ -11,21 +12,21 @@ import (
 
 // OSGitTagOperations implements core.GitTagOperations using actual git commands.
 type OSGitTagOperations struct {
-	execCommand func(name string, arg ...string) *exec.Cmd
+	execCommandContext func(ctx context.Context, name string, arg ...string) *exec.Cmd
 }
 
-// NewOSGitTagOperations creates a new OSGitTagOperations with the default exec.Command.
+// NewOSGitTagOperations creates a new OSGitTagOperations with the default exec.CommandContext.
 func NewOSGitTagOperations() *OSGitTagOperations {
 	return &OSGitTagOperations{
-		execCommand: exec.Command,
+		execCommandContext: exec.CommandContext,
 	}
 }
 
 // Verify OSGitTagOperations implements core.GitTagOperations.
 var _ core.GitTagOperations = (*OSGitTagOperations)(nil)
 
-func (g *OSGitTagOperations) CreateAnnotatedTag(name, message string) error {
-	cmd := g.execCommand("git", "tag", "-a", name, "-m", message)
+func (g *OSGitTagOperations) CreateAnnotatedTag(ctx context.Context, name, message string) error {
+	cmd := g.execCommandContext(ctx, "git", "tag", "-a", name, "-m", message)
 	var stderr bytes.Buffer
 	cmd.Stderr = &stderr
 
@@ -39,8 +40,8 @@ func (g *OSGitTagOperations) CreateAnnotatedTag(name, message string) error {
 	return nil
 }
 
-func (g *OSGitTagOperations) CreateLightweightTag(name string) error {
-	cmd := g.execCommand("git", "tag", name)
+func (g *OSGitTagOperations) CreateLightweightTag(ctx context.Context, name string) error {
+	cmd := g.execCommandContext(ctx, "git", "tag", name)
 	var stderr bytes.Buffer
 	cmd.Stderr = &stderr
 
@@ -54,7 +55,7 @@ func (g *OSGitTagOperations) CreateLightweightTag(name string) error {
 	return nil
 }
 
-func (g *OSGitTagOperations) CreateSignedTag(name, message, keyID string) error {
+func (g *OSGitTagOperations) CreateSignedTag(ctx context.Context, name, message, keyID string) error {
 	var args []string
 	if keyID != "" {
 		args = []string{"tag", "-s", "-u", keyID, name, "-m", message}
@@ -62,7 +63,7 @@ func (g *OSGitTagOperations) CreateSignedTag(name, message, keyID string) error 
 		args = []string{"tag", "-s", name, "-m", message}
 	}
 
-	cmd := g.execCommand("git", args...)
+	cmd := g.execCommandContext(ctx, "git", args...)
 	var stderr bytes.Buffer
 	cmd.Stderr = &stderr
 
@@ -76,8 +77,8 @@ func (g *OSGitTagOperations) CreateSignedTag(name, message, keyID string) error 
 	return nil
 }
 
-func (g *OSGitTagOperations) TagExists(name string) (bool, error) {
-	cmd := g.execCommand("git", "tag", "-l", name)
+func (g *OSGitTagOperations) TagExists(ctx context.Context, name string) (bool, error) {
+	cmd := g.execCommandContext(ctx, "git", "tag", "-l", name)
 	var stdout bytes.Buffer
 	cmd.Stdout = &stdout
 
@@ -90,8 +91,8 @@ func (g *OSGitTagOperations) TagExists(name string) (bool, error) {
 	return output == name, nil
 }
 
-func (g *OSGitTagOperations) GetLatestTag() (string, error) {
-	cmd := g.execCommand("git", "describe", "--tags", "--abbrev=0")
+func (g *OSGitTagOperations) GetLatestTag(ctx context.Context) (string, error) {
+	cmd := g.execCommandContext(ctx, "git", "describe", "--tags", "--abbrev=0")
 	var stdout, stderr bytes.Buffer
 	cmd.Stdout = &stdout
 	cmd.Stderr = &stderr
@@ -112,8 +113,8 @@ func (g *OSGitTagOperations) GetLatestTag() (string, error) {
 	return tag, nil
 }
 
-func (g *OSGitTagOperations) PushTag(name string) error {
-	cmd := g.execCommand("git", "push", "origin", name)
+func (g *OSGitTagOperations) PushTag(ctx context.Context, name string) error {
+	cmd := g.execCommandContext(ctx, "git", "push", "origin", name)
 	var stderr bytes.Buffer
 	cmd.Stderr = &stderr
 
@@ -127,13 +128,13 @@ func (g *OSGitTagOperations) PushTag(name string) error {
 	return nil
 }
 
-func (g *OSGitTagOperations) ListTags(pattern string) ([]string, error) {
+func (g *OSGitTagOperations) ListTags(ctx context.Context, pattern string) ([]string, error) {
 	args := []string{"tag", "-l"}
 	if pattern != "" {
 		args = append(args, pattern)
 	}
 
-	cmd := g.execCommand("git", args...)
+	cmd := g.execCommandContext(ctx, "git", args...)
 	var stdout, stderr bytes.Buffer
 	cmd.Stdout = &stdout
 	cmd.Stderr = &stderr
@@ -154,8 +155,8 @@ func (g *OSGitTagOperations) ListTags(pattern string) ([]string, error) {
 	return strings.Split(output, "\n"), nil
 }
 
-func (g *OSGitTagOperations) DeleteTag(name string) error {
-	cmd := g.execCommand("git", "tag", "-d", name)
+func (g *OSGitTagOperations) DeleteTag(ctx context.Context, name string) error {
+	cmd := g.execCommandContext(ctx, "git", "tag", "-d", name)
 	var stderr bytes.Buffer
 	cmd.Stderr = &stderr
 
@@ -169,8 +170,8 @@ func (g *OSGitTagOperations) DeleteTag(name string) error {
 	return nil
 }
 
-func (g *OSGitTagOperations) DeleteRemoteTag(name string) error {
-	cmd := g.execCommand("git", "push", "origin", "--delete", name)
+func (g *OSGitTagOperations) DeleteRemoteTag(ctx context.Context, name string) error {
+	cmd := g.execCommandContext(ctx, "git", "push", "origin", "--delete", name)
 	var stderr bytes.Buffer
 	cmd.Stderr = &stderr
 
@@ -186,25 +187,25 @@ func (g *OSGitTagOperations) DeleteRemoteTag(name string) error {
 
 // OSGitCommitOperations implements core.GitCommitOperations using actual git commands.
 type OSGitCommitOperations struct {
-	execCommand func(name string, arg ...string) *exec.Cmd
+	execCommandContext func(ctx context.Context, name string, arg ...string) *exec.Cmd
 }
 
-// NewOSGitCommitOperations creates a new OSGitCommitOperations with the default exec.Command.
+// NewOSGitCommitOperations creates a new OSGitCommitOperations with the default exec.CommandContext.
 func NewOSGitCommitOperations() *OSGitCommitOperations {
 	return &OSGitCommitOperations{
-		execCommand: exec.Command,
+		execCommandContext: exec.CommandContext,
 	}
 }
 
 // Verify OSGitCommitOperations implements core.GitCommitOperations.
 var _ core.GitCommitOperations = (*OSGitCommitOperations)(nil)
 
-func (g *OSGitCommitOperations) StageFiles(files ...string) error {
+func (g *OSGitCommitOperations) StageFiles(ctx context.Context, files ...string) error {
 	if len(files) == 0 {
 		return nil
 	}
 	args := append([]string{"add", "--"}, files...)
-	cmd := g.execCommand("git", args...)
+	cmd := g.execCommandContext(ctx, "git", args...)
 	var stderr bytes.Buffer
 	cmd.Stderr = &stderr
 
@@ -218,8 +219,8 @@ func (g *OSGitCommitOperations) StageFiles(files ...string) error {
 	return nil
 }
 
-func (g *OSGitCommitOperations) Commit(message string) error {
-	cmd := g.execCommand("git", "commit", "-m", message)
+func (g *OSGitCommitOperations) Commit(ctx context.Context, message string) error {
+	cmd := g.execCommandContext(ctx, "git", "commit", "-m", message)
 	var stderr bytes.Buffer
 	cmd.Stderr = &stderr
 
@@ -233,8 +234,8 @@ func (g *OSGitCommitOperations) Commit(message string) error {
 	return nil
 }
 
-func (g *OSGitCommitOperations) GetModifiedFiles() ([]string, error) {
-	cmd := g.execCommand("git", "status", "--porcelain")
+func (g *OSGitCommitOperations) GetModifiedFiles(ctx context.Context) ([]string, error) {
+	cmd := g.execCommandContext(ctx, "git", "status", "--porcelain")
 	var stdout, stderr bytes.Buffer
 	cmd.Stdout = &stdout
 	cmd.Stderr = &stderr
@@ -274,10 +275,10 @@ var defaultGitTagOps = NewOSGitTagOperations()
 
 // ListTags returns all git tags matching a pattern (package-level convenience function).
 func ListTags(pattern string) ([]string, error) {
-	return defaultGitTagOps.ListTags(pattern)
+	return defaultGitTagOps.ListTags(context.Background(), pattern)
 }
 
 // DeleteTag deletes a local git tag (package-level convenience function).
 func DeleteTag(name string) error {
-	return defaultGitTagOps.DeleteTag(name)
+	return defaultGitTagOps.DeleteTag(context.Background(), name)
 }

--- a/internal/plugins/tagmanager/git_test.go
+++ b/internal/plugins/tagmanager/git_test.go
@@ -1,21 +1,22 @@
 package tagmanager
 
 import (
+	"context"
 	"os/exec"
 	"slices"
 	"testing"
 )
 
-// createTestGitTagOps creates an OSGitTagOperations with a custom exec.Command for testing.
-func createTestGitTagOps(mockExec func(name string, args ...string) *exec.Cmd) *OSGitTagOperations {
+// createTestGitTagOps creates an OSGitTagOperations with a custom exec.CommandContext for testing.
+func createTestGitTagOps(mockExec func(ctx context.Context, name string, args ...string) *exec.Cmd) *OSGitTagOperations {
 	return &OSGitTagOperations{
-		execCommand: mockExec,
+		execCommandContext: mockExec,
 	}
 }
 
 func TestOSGitTagOperations_CreateAnnotatedTag(t *testing.T) {
 	t.Run("success", func(t *testing.T) {
-		ops := createTestGitTagOps(func(name string, args ...string) *exec.Cmd {
+		ops := createTestGitTagOps(func(ctx context.Context, name string, args ...string) *exec.Cmd {
 			// Verify correct arguments
 			if name != "git" {
 				t.Errorf("expected git command, got %s", name)
@@ -26,18 +27,18 @@ func TestOSGitTagOperations_CreateAnnotatedTag(t *testing.T) {
 			return exec.Command("true")
 		})
 
-		err := ops.CreateAnnotatedTag("v1.0.0", "Release 1.0.0")
+		err := ops.CreateAnnotatedTag(context.Background(), "v1.0.0", "Release 1.0.0")
 		if err != nil {
 			t.Errorf("CreateAnnotatedTag() error = %v", err)
 		}
 	})
 
 	t.Run("error with stderr", func(t *testing.T) {
-		ops := createTestGitTagOps(func(name string, args ...string) *exec.Cmd {
+		ops := createTestGitTagOps(func(ctx context.Context, name string, args ...string) *exec.Cmd {
 			return exec.Command("sh", "-c", "echo 'tag already exists' >&2 && exit 1")
 		})
 
-		err := ops.CreateAnnotatedTag("v1.0.0", "Release 1.0.0")
+		err := ops.CreateAnnotatedTag(context.Background(), "v1.0.0", "Release 1.0.0")
 		if err == nil {
 			t.Error("CreateAnnotatedTag() expected error")
 		}
@@ -47,11 +48,11 @@ func TestOSGitTagOperations_CreateAnnotatedTag(t *testing.T) {
 	})
 
 	t.Run("error without stderr", func(t *testing.T) {
-		ops := createTestGitTagOps(func(name string, args ...string) *exec.Cmd {
+		ops := createTestGitTagOps(func(ctx context.Context, name string, args ...string) *exec.Cmd {
 			return exec.Command("false")
 		})
 
-		err := ops.CreateAnnotatedTag("v1.0.0", "Release 1.0.0")
+		err := ops.CreateAnnotatedTag(context.Background(), "v1.0.0", "Release 1.0.0")
 		if err == nil {
 			t.Error("CreateAnnotatedTag() expected error")
 		}
@@ -60,36 +61,36 @@ func TestOSGitTagOperations_CreateAnnotatedTag(t *testing.T) {
 
 func TestOSGitTagOperations_CreateLightweightTag(t *testing.T) {
 	t.Run("success", func(t *testing.T) {
-		ops := createTestGitTagOps(func(name string, args ...string) *exec.Cmd {
+		ops := createTestGitTagOps(func(ctx context.Context, name string, args ...string) *exec.Cmd {
 			if name != "git" || len(args) < 2 || args[0] != "tag" {
 				t.Errorf("unexpected command: %s %v", name, args)
 			}
 			return exec.Command("true")
 		})
 
-		err := ops.CreateLightweightTag("v1.0.0")
+		err := ops.CreateLightweightTag(context.Background(), "v1.0.0")
 		if err != nil {
 			t.Errorf("CreateLightweightTag() error = %v", err)
 		}
 	})
 
 	t.Run("error with stderr", func(t *testing.T) {
-		ops := createTestGitTagOps(func(name string, args ...string) *exec.Cmd {
+		ops := createTestGitTagOps(func(ctx context.Context, name string, args ...string) *exec.Cmd {
 			return exec.Command("sh", "-c", "echo 'error' >&2 && exit 1")
 		})
 
-		err := ops.CreateLightweightTag("v1.0.0")
+		err := ops.CreateLightweightTag(context.Background(), "v1.0.0")
 		if err == nil {
 			t.Error("CreateLightweightTag() expected error")
 		}
 	})
 
 	t.Run("error without stderr", func(t *testing.T) {
-		ops := createTestGitTagOps(func(name string, args ...string) *exec.Cmd {
+		ops := createTestGitTagOps(func(ctx context.Context, name string, args ...string) *exec.Cmd {
 			return exec.Command("false")
 		})
 
-		err := ops.CreateLightweightTag("v1.0.0")
+		err := ops.CreateLightweightTag(context.Background(), "v1.0.0")
 		if err == nil {
 			t.Error("CreateLightweightTag() expected error")
 		}
@@ -97,7 +98,7 @@ func TestOSGitTagOperations_CreateLightweightTag(t *testing.T) {
 }
 
 func TestOSGitTagOperations_CreateSignedTag_WithoutKey(t *testing.T) {
-	ops := createTestGitTagOps(func(name string, args ...string) *exec.Cmd {
+	ops := createTestGitTagOps(func(ctx context.Context, name string, args ...string) *exec.Cmd {
 		if name != "git" {
 			t.Errorf("expected git command, got %s", name)
 		}
@@ -110,14 +111,14 @@ func TestOSGitTagOperations_CreateSignedTag_WithoutKey(t *testing.T) {
 		return exec.Command("true")
 	})
 
-	err := ops.CreateSignedTag("v1.0.0", "Release 1.0.0", "")
+	err := ops.CreateSignedTag(context.Background(), "v1.0.0", "Release 1.0.0", "")
 	if err != nil {
 		t.Errorf("CreateSignedTag() error = %v", err)
 	}
 }
 
 func TestOSGitTagOperations_CreateSignedTag_WithKey(t *testing.T) {
-	ops := createTestGitTagOps(func(name string, args ...string) *exec.Cmd {
+	ops := createTestGitTagOps(func(ctx context.Context, name string, args ...string) *exec.Cmd {
 		if name != "git" {
 			t.Errorf("expected git command, got %s", name)
 		}
@@ -127,18 +128,18 @@ func TestOSGitTagOperations_CreateSignedTag_WithKey(t *testing.T) {
 		return exec.Command("true")
 	})
 
-	err := ops.CreateSignedTag("v1.0.0", "Release 1.0.0", "ABC123")
+	err := ops.CreateSignedTag(context.Background(), "v1.0.0", "Release 1.0.0", "ABC123")
 	if err != nil {
 		t.Errorf("CreateSignedTag() error = %v", err)
 	}
 }
 
 func TestOSGitTagOperations_CreateSignedTag_ErrorWithStderr(t *testing.T) {
-	ops := createTestGitTagOps(func(name string, args ...string) *exec.Cmd {
+	ops := createTestGitTagOps(func(ctx context.Context, name string, args ...string) *exec.Cmd {
 		return exec.Command("sh", "-c", "echo 'gpg: signing failed: No secret key' >&2 && exit 1")
 	})
 
-	err := ops.CreateSignedTag("v1.0.0", "Release 1.0.0", "")
+	err := ops.CreateSignedTag(context.Background(), "v1.0.0", "Release 1.0.0", "")
 	if err == nil {
 		t.Error("CreateSignedTag() expected error")
 	}
@@ -148,11 +149,11 @@ func TestOSGitTagOperations_CreateSignedTag_ErrorWithStderr(t *testing.T) {
 }
 
 func TestOSGitTagOperations_CreateSignedTag_ErrorWithoutStderr(t *testing.T) {
-	ops := createTestGitTagOps(func(name string, args ...string) *exec.Cmd {
+	ops := createTestGitTagOps(func(ctx context.Context, name string, args ...string) *exec.Cmd {
 		return exec.Command("false")
 	})
 
-	err := ops.CreateSignedTag("v1.0.0", "Release 1.0.0", "")
+	err := ops.CreateSignedTag(context.Background(), "v1.0.0", "Release 1.0.0", "")
 	if err == nil {
 		t.Error("CreateSignedTag() expected error")
 	}
@@ -160,11 +161,11 @@ func TestOSGitTagOperations_CreateSignedTag_ErrorWithoutStderr(t *testing.T) {
 
 func TestOSGitTagOperations_TagExists(t *testing.T) {
 	t.Run("tag exists", func(t *testing.T) {
-		ops := createTestGitTagOps(func(name string, args ...string) *exec.Cmd {
+		ops := createTestGitTagOps(func(ctx context.Context, name string, args ...string) *exec.Cmd {
 			return exec.Command("echo", "v1.0.0")
 		})
 
-		exists, err := ops.TagExists("v1.0.0")
+		exists, err := ops.TagExists(context.Background(), "v1.0.0")
 		if err != nil {
 			t.Errorf("TagExists() error = %v", err)
 		}
@@ -174,11 +175,11 @@ func TestOSGitTagOperations_TagExists(t *testing.T) {
 	})
 
 	t.Run("tag does not exist", func(t *testing.T) {
-		ops := createTestGitTagOps(func(name string, args ...string) *exec.Cmd {
+		ops := createTestGitTagOps(func(ctx context.Context, name string, args ...string) *exec.Cmd {
 			return exec.Command("echo", "")
 		})
 
-		exists, err := ops.TagExists("v1.0.0")
+		exists, err := ops.TagExists(context.Background(), "v1.0.0")
 		if err != nil {
 			t.Errorf("TagExists() error = %v", err)
 		}
@@ -188,11 +189,11 @@ func TestOSGitTagOperations_TagExists(t *testing.T) {
 	})
 
 	t.Run("error", func(t *testing.T) {
-		ops := createTestGitTagOps(func(name string, args ...string) *exec.Cmd {
+		ops := createTestGitTagOps(func(ctx context.Context, name string, args ...string) *exec.Cmd {
 			return exec.Command("false")
 		})
 
-		_, err := ops.TagExists("v1.0.0")
+		_, err := ops.TagExists(context.Background(), "v1.0.0")
 		if err == nil {
 			t.Error("TagExists() expected error")
 		}
@@ -201,11 +202,11 @@ func TestOSGitTagOperations_TagExists(t *testing.T) {
 
 func TestOSGitTagOperations_GetLatestTag(t *testing.T) {
 	t.Run("success", func(t *testing.T) {
-		ops := createTestGitTagOps(func(name string, args ...string) *exec.Cmd {
+		ops := createTestGitTagOps(func(ctx context.Context, name string, args ...string) *exec.Cmd {
 			return exec.Command("echo", "v1.2.3")
 		})
 
-		tag, err := ops.GetLatestTag()
+		tag, err := ops.GetLatestTag(context.Background())
 		if err != nil {
 			t.Errorf("GetLatestTag() error = %v", err)
 		}
@@ -215,33 +216,33 @@ func TestOSGitTagOperations_GetLatestTag(t *testing.T) {
 	})
 
 	t.Run("empty output", func(t *testing.T) {
-		ops := createTestGitTagOps(func(name string, args ...string) *exec.Cmd {
+		ops := createTestGitTagOps(func(ctx context.Context, name string, args ...string) *exec.Cmd {
 			return exec.Command("echo", "")
 		})
 
-		_, err := ops.GetLatestTag()
+		_, err := ops.GetLatestTag(context.Background())
 		if err == nil {
 			t.Error("GetLatestTag() expected error for empty output")
 		}
 	})
 
 	t.Run("error with stderr", func(t *testing.T) {
-		ops := createTestGitTagOps(func(name string, args ...string) *exec.Cmd {
+		ops := createTestGitTagOps(func(ctx context.Context, name string, args ...string) *exec.Cmd {
 			return exec.Command("sh", "-c", "echo 'fatal: No names found' >&2 && exit 128")
 		})
 
-		_, err := ops.GetLatestTag()
+		_, err := ops.GetLatestTag(context.Background())
 		if err == nil {
 			t.Error("GetLatestTag() expected error")
 		}
 	})
 
 	t.Run("error without stderr", func(t *testing.T) {
-		ops := createTestGitTagOps(func(name string, args ...string) *exec.Cmd {
+		ops := createTestGitTagOps(func(ctx context.Context, name string, args ...string) *exec.Cmd {
 			return exec.Command("false")
 		})
 
-		_, err := ops.GetLatestTag()
+		_, err := ops.GetLatestTag(context.Background())
 		if err == nil {
 			t.Error("GetLatestTag() expected error")
 		}
@@ -250,36 +251,36 @@ func TestOSGitTagOperations_GetLatestTag(t *testing.T) {
 
 func TestOSGitTagOperations_PushTag(t *testing.T) {
 	t.Run("success", func(t *testing.T) {
-		ops := createTestGitTagOps(func(name string, args ...string) *exec.Cmd {
+		ops := createTestGitTagOps(func(ctx context.Context, name string, args ...string) *exec.Cmd {
 			if name != "git" || len(args) < 3 || args[0] != "push" || args[1] != "origin" {
 				t.Errorf("unexpected command: %s %v", name, args)
 			}
 			return exec.Command("true")
 		})
 
-		err := ops.PushTag("v1.0.0")
+		err := ops.PushTag(context.Background(), "v1.0.0")
 		if err != nil {
 			t.Errorf("PushTag() error = %v", err)
 		}
 	})
 
 	t.Run("error with stderr", func(t *testing.T) {
-		ops := createTestGitTagOps(func(name string, args ...string) *exec.Cmd {
+		ops := createTestGitTagOps(func(ctx context.Context, name string, args ...string) *exec.Cmd {
 			return exec.Command("sh", "-c", "echo 'remote rejected' >&2 && exit 1")
 		})
 
-		err := ops.PushTag("v1.0.0")
+		err := ops.PushTag(context.Background(), "v1.0.0")
 		if err == nil {
 			t.Error("PushTag() expected error")
 		}
 	})
 
 	t.Run("error without stderr", func(t *testing.T) {
-		ops := createTestGitTagOps(func(name string, args ...string) *exec.Cmd {
+		ops := createTestGitTagOps(func(ctx context.Context, name string, args ...string) *exec.Cmd {
 			return exec.Command("false")
 		})
 
-		err := ops.PushTag("v1.0.0")
+		err := ops.PushTag(context.Background(), "v1.0.0")
 		if err == nil {
 			t.Error("PushTag() expected error")
 		}
@@ -288,11 +289,11 @@ func TestOSGitTagOperations_PushTag(t *testing.T) {
 
 func TestOSGitTagOperations_ListTags(t *testing.T) {
 	t.Run("list all tags", func(t *testing.T) {
-		ops := createTestGitTagOps(func(name string, args ...string) *exec.Cmd {
+		ops := createTestGitTagOps(func(ctx context.Context, name string, args ...string) *exec.Cmd {
 			return exec.Command("printf", "v1.0.0\nv1.1.0\nv2.0.0")
 		})
 
-		tags, err := ops.ListTags("")
+		tags, err := ops.ListTags(context.Background(), "")
 		if err != nil {
 			t.Errorf("ListTags() error = %v", err)
 		}
@@ -302,7 +303,7 @@ func TestOSGitTagOperations_ListTags(t *testing.T) {
 	})
 
 	t.Run("list with pattern", func(t *testing.T) {
-		ops := createTestGitTagOps(func(name string, args ...string) *exec.Cmd {
+		ops := createTestGitTagOps(func(ctx context.Context, name string, args ...string) *exec.Cmd {
 			// Verify pattern is passed
 			if len(args) < 3 || args[2] != "v1.*" {
 				t.Errorf("expected pattern v1.*, got args: %v", args)
@@ -310,7 +311,7 @@ func TestOSGitTagOperations_ListTags(t *testing.T) {
 			return exec.Command("printf", "v1.0.0\nv1.1.0")
 		})
 
-		tags, err := ops.ListTags("v1.*")
+		tags, err := ops.ListTags(context.Background(), "v1.*")
 		if err != nil {
 			t.Errorf("ListTags() error = %v", err)
 		}
@@ -320,11 +321,11 @@ func TestOSGitTagOperations_ListTags(t *testing.T) {
 	})
 
 	t.Run("empty result", func(t *testing.T) {
-		ops := createTestGitTagOps(func(name string, args ...string) *exec.Cmd {
+		ops := createTestGitTagOps(func(ctx context.Context, name string, args ...string) *exec.Cmd {
 			return exec.Command("echo", "")
 		})
 
-		tags, err := ops.ListTags("nonexistent*")
+		tags, err := ops.ListTags(context.Background(), "nonexistent*")
 		if err != nil {
 			t.Errorf("ListTags() error = %v", err)
 		}
@@ -334,22 +335,22 @@ func TestOSGitTagOperations_ListTags(t *testing.T) {
 	})
 
 	t.Run("error with stderr", func(t *testing.T) {
-		ops := createTestGitTagOps(func(name string, args ...string) *exec.Cmd {
+		ops := createTestGitTagOps(func(ctx context.Context, name string, args ...string) *exec.Cmd {
 			return exec.Command("sh", "-c", "echo 'git error' >&2 && exit 1")
 		})
 
-		_, err := ops.ListTags("")
+		_, err := ops.ListTags(context.Background(), "")
 		if err == nil {
 			t.Error("ListTags() expected error")
 		}
 	})
 
 	t.Run("error without stderr", func(t *testing.T) {
-		ops := createTestGitTagOps(func(name string, args ...string) *exec.Cmd {
+		ops := createTestGitTagOps(func(ctx context.Context, name string, args ...string) *exec.Cmd {
 			return exec.Command("false")
 		})
 
-		_, err := ops.ListTags("")
+		_, err := ops.ListTags(context.Background(), "")
 		if err == nil {
 			t.Error("ListTags() expected error")
 		}
@@ -358,36 +359,36 @@ func TestOSGitTagOperations_ListTags(t *testing.T) {
 
 func TestOSGitTagOperations_DeleteTag(t *testing.T) {
 	t.Run("success", func(t *testing.T) {
-		ops := createTestGitTagOps(func(name string, args ...string) *exec.Cmd {
+		ops := createTestGitTagOps(func(ctx context.Context, name string, args ...string) *exec.Cmd {
 			if name != "git" || len(args) < 3 || args[0] != "tag" || args[1] != "-d" {
 				t.Errorf("unexpected command: %s %v", name, args)
 			}
 			return exec.Command("true")
 		})
 
-		err := ops.DeleteTag("v1.0.0")
+		err := ops.DeleteTag(context.Background(), "v1.0.0")
 		if err != nil {
 			t.Errorf("DeleteTag() error = %v", err)
 		}
 	})
 
 	t.Run("error with stderr", func(t *testing.T) {
-		ops := createTestGitTagOps(func(name string, args ...string) *exec.Cmd {
+		ops := createTestGitTagOps(func(ctx context.Context, name string, args ...string) *exec.Cmd {
 			return exec.Command("sh", "-c", "echo 'tag not found' >&2 && exit 1")
 		})
 
-		err := ops.DeleteTag("v1.0.0")
+		err := ops.DeleteTag(context.Background(), "v1.0.0")
 		if err == nil {
 			t.Error("DeleteTag() expected error")
 		}
 	})
 
 	t.Run("error without stderr", func(t *testing.T) {
-		ops := createTestGitTagOps(func(name string, args ...string) *exec.Cmd {
+		ops := createTestGitTagOps(func(ctx context.Context, name string, args ...string) *exec.Cmd {
 			return exec.Command("false")
 		})
 
-		err := ops.DeleteTag("v1.0.0")
+		err := ops.DeleteTag(context.Background(), "v1.0.0")
 		if err == nil {
 			t.Error("DeleteTag() expected error")
 		}
@@ -396,36 +397,36 @@ func TestOSGitTagOperations_DeleteTag(t *testing.T) {
 
 func TestOSGitTagOperations_DeleteRemoteTag(t *testing.T) {
 	t.Run("success", func(t *testing.T) {
-		ops := createTestGitTagOps(func(name string, args ...string) *exec.Cmd {
+		ops := createTestGitTagOps(func(ctx context.Context, name string, args ...string) *exec.Cmd {
 			if name != "git" || len(args) < 4 || args[0] != "push" || args[1] != "origin" || args[2] != "--delete" {
 				t.Errorf("unexpected command: %s %v", name, args)
 			}
 			return exec.Command("true")
 		})
 
-		err := ops.DeleteRemoteTag("v1.0.0")
+		err := ops.DeleteRemoteTag(context.Background(), "v1.0.0")
 		if err != nil {
 			t.Errorf("DeleteRemoteTag() error = %v", err)
 		}
 	})
 
 	t.Run("error with stderr", func(t *testing.T) {
-		ops := createTestGitTagOps(func(name string, args ...string) *exec.Cmd {
+		ops := createTestGitTagOps(func(ctx context.Context, name string, args ...string) *exec.Cmd {
 			return exec.Command("sh", "-c", "echo 'remote ref not found' >&2 && exit 1")
 		})
 
-		err := ops.DeleteRemoteTag("v1.0.0")
+		err := ops.DeleteRemoteTag(context.Background(), "v1.0.0")
 		if err == nil {
 			t.Error("DeleteRemoteTag() expected error")
 		}
 	})
 
 	t.Run("error without stderr", func(t *testing.T) {
-		ops := createTestGitTagOps(func(name string, args ...string) *exec.Cmd {
+		ops := createTestGitTagOps(func(ctx context.Context, name string, args ...string) *exec.Cmd {
 			return exec.Command("false")
 		})
 
-		err := ops.DeleteRemoteTag("v1.0.0")
+		err := ops.DeleteRemoteTag(context.Background(), "v1.0.0")
 		if err == nil {
 			t.Error("DeleteRemoteTag() expected error")
 		}
@@ -437,15 +438,15 @@ func TestNewOSGitTagOperations(t *testing.T) {
 	if ops == nil {
 		t.Fatal("NewOSGitTagOperations() returned nil")
 	}
-	if ops.execCommand == nil {
-		t.Error("execCommand should not be nil")
+	if ops.execCommandContext == nil {
+		t.Error("execCommandContext should not be nil")
 	}
 }
 
-// createTestGitCommitOps creates an OSGitCommitOperations with a custom exec.Command for testing.
-func createTestGitCommitOps(mockExec func(name string, args ...string) *exec.Cmd) *OSGitCommitOperations {
+// createTestGitCommitOps creates an OSGitCommitOperations with a custom exec.CommandContext for testing.
+func createTestGitCommitOps(mockExec func(ctx context.Context, name string, args ...string) *exec.Cmd) *OSGitCommitOperations {
 	return &OSGitCommitOperations{
-		execCommand: mockExec,
+		execCommandContext: mockExec,
 	}
 }
 
@@ -454,14 +455,14 @@ func TestNewOSGitCommitOperations(t *testing.T) {
 	if ops == nil {
 		t.Fatal("NewOSGitCommitOperations() returned nil")
 	}
-	if ops.execCommand == nil {
-		t.Error("execCommand should not be nil")
+	if ops.execCommandContext == nil {
+		t.Error("execCommandContext should not be nil")
 	}
 }
 
 func TestOSGitCommitOperations_StageFiles(t *testing.T) {
 	t.Run("success", func(t *testing.T) {
-		ops := createTestGitCommitOps(func(name string, args ...string) *exec.Cmd {
+		ops := createTestGitCommitOps(func(ctx context.Context, name string, args ...string) *exec.Cmd {
 			if name != "git" {
 				t.Errorf("expected git command, got %s", name)
 			}
@@ -471,41 +472,41 @@ func TestOSGitCommitOperations_StageFiles(t *testing.T) {
 			return exec.Command("true")
 		})
 
-		err := ops.StageFiles("file1.txt", "file2.txt")
+		err := ops.StageFiles(context.Background(), "file1.txt", "file2.txt")
 		if err != nil {
 			t.Errorf("StageFiles() error = %v", err)
 		}
 	})
 
 	t.Run("empty files", func(t *testing.T) {
-		ops := createTestGitCommitOps(func(name string, args ...string) *exec.Cmd {
+		ops := createTestGitCommitOps(func(ctx context.Context, name string, args ...string) *exec.Cmd {
 			t.Error("exec should not be called for empty files")
 			return exec.Command("true")
 		})
 
-		err := ops.StageFiles()
+		err := ops.StageFiles(context.Background())
 		if err != nil {
 			t.Errorf("StageFiles() error = %v", err)
 		}
 	})
 
 	t.Run("error with stderr", func(t *testing.T) {
-		ops := createTestGitCommitOps(func(name string, args ...string) *exec.Cmd {
+		ops := createTestGitCommitOps(func(ctx context.Context, name string, args ...string) *exec.Cmd {
 			return exec.Command("sh", "-c", "echo 'pathspec not found' >&2 && exit 1")
 		})
 
-		err := ops.StageFiles("nonexistent.txt")
+		err := ops.StageFiles(context.Background(), "nonexistent.txt")
 		if err == nil {
 			t.Error("StageFiles() expected error")
 		}
 	})
 
 	t.Run("error without stderr", func(t *testing.T) {
-		ops := createTestGitCommitOps(func(name string, args ...string) *exec.Cmd {
+		ops := createTestGitCommitOps(func(ctx context.Context, name string, args ...string) *exec.Cmd {
 			return exec.Command("false")
 		})
 
-		err := ops.StageFiles("file.txt")
+		err := ops.StageFiles(context.Background(), "file.txt")
 		if err == nil {
 			t.Error("StageFiles() expected error")
 		}
@@ -514,7 +515,7 @@ func TestOSGitCommitOperations_StageFiles(t *testing.T) {
 
 func TestOSGitCommitOperations_Commit(t *testing.T) {
 	t.Run("success", func(t *testing.T) {
-		ops := createTestGitCommitOps(func(name string, args ...string) *exec.Cmd {
+		ops := createTestGitCommitOps(func(ctx context.Context, name string, args ...string) *exec.Cmd {
 			if name != "git" {
 				t.Errorf("expected git command, got %s", name)
 			}
@@ -527,29 +528,29 @@ func TestOSGitCommitOperations_Commit(t *testing.T) {
 			return exec.Command("true")
 		})
 
-		err := ops.Commit("chore(release): v1.0.0")
+		err := ops.Commit(context.Background(), "chore(release): v1.0.0")
 		if err != nil {
 			t.Errorf("Commit() error = %v", err)
 		}
 	})
 
 	t.Run("error with stderr", func(t *testing.T) {
-		ops := createTestGitCommitOps(func(name string, args ...string) *exec.Cmd {
+		ops := createTestGitCommitOps(func(ctx context.Context, name string, args ...string) *exec.Cmd {
 			return exec.Command("sh", "-c", "echo 'nothing to commit' >&2 && exit 1")
 		})
 
-		err := ops.Commit("some message")
+		err := ops.Commit(context.Background(), "some message")
 		if err == nil {
 			t.Error("Commit() expected error")
 		}
 	})
 
 	t.Run("error without stderr", func(t *testing.T) {
-		ops := createTestGitCommitOps(func(name string, args ...string) *exec.Cmd {
+		ops := createTestGitCommitOps(func(ctx context.Context, name string, args ...string) *exec.Cmd {
 			return exec.Command("false")
 		})
 
-		err := ops.Commit("some message")
+		err := ops.Commit(context.Background(), "some message")
 		if err == nil {
 			t.Error("Commit() expected error")
 		}
@@ -558,11 +559,11 @@ func TestOSGitCommitOperations_Commit(t *testing.T) {
 
 func TestOSGitCommitOperations_GetModifiedFiles(t *testing.T) {
 	t.Run("files modified", func(t *testing.T) {
-		ops := createTestGitCommitOps(func(name string, args ...string) *exec.Cmd {
+		ops := createTestGitCommitOps(func(ctx context.Context, name string, args ...string) *exec.Cmd {
 			return exec.Command("printf", " M file1.txt\n?? file2.txt\nM  file3.txt")
 		})
 
-		files, err := ops.GetModifiedFiles()
+		files, err := ops.GetModifiedFiles(context.Background())
 		if err != nil {
 			t.Errorf("GetModifiedFiles() error = %v", err)
 		}
@@ -572,11 +573,11 @@ func TestOSGitCommitOperations_GetModifiedFiles(t *testing.T) {
 	})
 
 	t.Run("no modified files", func(t *testing.T) {
-		ops := createTestGitCommitOps(func(name string, args ...string) *exec.Cmd {
+		ops := createTestGitCommitOps(func(ctx context.Context, name string, args ...string) *exec.Cmd {
 			return exec.Command("echo", "")
 		})
 
-		files, err := ops.GetModifiedFiles()
+		files, err := ops.GetModifiedFiles(context.Background())
 		if err != nil {
 			t.Errorf("GetModifiedFiles() error = %v", err)
 		}
@@ -586,22 +587,22 @@ func TestOSGitCommitOperations_GetModifiedFiles(t *testing.T) {
 	})
 
 	t.Run("error with stderr", func(t *testing.T) {
-		ops := createTestGitCommitOps(func(name string, args ...string) *exec.Cmd {
+		ops := createTestGitCommitOps(func(ctx context.Context, name string, args ...string) *exec.Cmd {
 			return exec.Command("sh", "-c", "echo 'not a git repo' >&2 && exit 128")
 		})
 
-		_, err := ops.GetModifiedFiles()
+		_, err := ops.GetModifiedFiles(context.Background())
 		if err == nil {
 			t.Error("GetModifiedFiles() expected error")
 		}
 	})
 
 	t.Run("error without stderr", func(t *testing.T) {
-		ops := createTestGitCommitOps(func(name string, args ...string) *exec.Cmd {
+		ops := createTestGitCommitOps(func(ctx context.Context, name string, args ...string) *exec.Cmd {
 			return exec.Command("false")
 		})
 
-		_, err := ops.GetModifiedFiles()
+		_, err := ops.GetModifiedFiles(context.Background())
 		if err == nil {
 			t.Error("GetModifiedFiles() expected error")
 		}

--- a/internal/plugins/tagmanager/mock_git_commit_ops.go
+++ b/internal/plugins/tagmanager/mock_git_commit_ops.go
@@ -1,37 +1,41 @@
 package tagmanager
 
-import "github.com/indaco/sley/internal/core"
+import (
+	"context"
+
+	"github.com/indaco/sley/internal/core"
+)
 
 // MockGitCommitOperations is a mock implementation of core.GitCommitOperations for testing.
 type MockGitCommitOperations struct {
-	StageFilesFn       func(files ...string) error
-	CommitFn           func(message string) error
-	GetModifiedFilesFn func() ([]string, error)
+	StageFilesFn       func(ctx context.Context, files ...string) error
+	CommitFn           func(ctx context.Context, message string) error
+	GetModifiedFilesFn func(ctx context.Context) ([]string, error)
 }
 
 // Verify MockGitCommitOperations implements core.GitCommitOperations.
 var _ core.GitCommitOperations = (*MockGitCommitOperations)(nil)
 
 // StageFiles implements core.GitCommitOperations.
-func (m *MockGitCommitOperations) StageFiles(files ...string) error {
+func (m *MockGitCommitOperations) StageFiles(ctx context.Context, files ...string) error {
 	if m.StageFilesFn != nil {
-		return m.StageFilesFn(files...)
+		return m.StageFilesFn(ctx, files...)
 	}
 	return nil
 }
 
 // Commit implements core.GitCommitOperations.
-func (m *MockGitCommitOperations) Commit(message string) error {
+func (m *MockGitCommitOperations) Commit(ctx context.Context, message string) error {
 	if m.CommitFn != nil {
-		return m.CommitFn(message)
+		return m.CommitFn(ctx, message)
 	}
 	return nil
 }
 
 // GetModifiedFiles implements core.GitCommitOperations.
-func (m *MockGitCommitOperations) GetModifiedFiles() ([]string, error) {
+func (m *MockGitCommitOperations) GetModifiedFiles(ctx context.Context) ([]string, error) {
 	if m.GetModifiedFilesFn != nil {
-		return m.GetModifiedFilesFn()
+		return m.GetModifiedFilesFn(ctx)
 	}
 	return []string{}, nil
 }

--- a/internal/plugins/tagmanager/mock_git_ops.go
+++ b/internal/plugins/tagmanager/mock_git_ops.go
@@ -1,91 +1,95 @@
 package tagmanager
 
-import "github.com/indaco/sley/internal/core"
+import (
+	"context"
+
+	"github.com/indaco/sley/internal/core"
+)
 
 // MockGitTagOperations is a mock implementation of core.GitTagOperations for testing.
 type MockGitTagOperations struct {
-	CreateAnnotatedTagFn   func(name, message string) error
-	CreateLightweightTagFn func(name string) error
-	CreateSignedTagFn      func(name, message, keyID string) error
-	TagExistsFn            func(name string) (bool, error)
-	GetLatestTagFn         func() (string, error)
-	PushTagFn              func(name string) error
-	ListTagsFn             func(pattern string) ([]string, error)
-	DeleteTagFn            func(name string) error
-	DeleteRemoteTagFn      func(name string) error
+	CreateAnnotatedTagFn   func(ctx context.Context, name, message string) error
+	CreateLightweightTagFn func(ctx context.Context, name string) error
+	CreateSignedTagFn      func(ctx context.Context, name, message, keyID string) error
+	TagExistsFn            func(ctx context.Context, name string) (bool, error)
+	GetLatestTagFn         func(ctx context.Context) (string, error)
+	PushTagFn              func(ctx context.Context, name string) error
+	ListTagsFn             func(ctx context.Context, pattern string) ([]string, error)
+	DeleteTagFn            func(ctx context.Context, name string) error
+	DeleteRemoteTagFn      func(ctx context.Context, name string) error
 }
 
 // Verify MockGitTagOperations implements core.GitTagOperations.
 var _ core.GitTagOperations = (*MockGitTagOperations)(nil)
 
 // CreateAnnotatedTag implements core.GitTagOperations.
-func (m *MockGitTagOperations) CreateAnnotatedTag(name, message string) error {
+func (m *MockGitTagOperations) CreateAnnotatedTag(ctx context.Context, name, message string) error {
 	if m.CreateAnnotatedTagFn != nil {
-		return m.CreateAnnotatedTagFn(name, message)
+		return m.CreateAnnotatedTagFn(ctx, name, message)
 	}
 	return nil
 }
 
 // CreateLightweightTag implements core.GitTagOperations.
-func (m *MockGitTagOperations) CreateLightweightTag(name string) error {
+func (m *MockGitTagOperations) CreateLightweightTag(ctx context.Context, name string) error {
 	if m.CreateLightweightTagFn != nil {
-		return m.CreateLightweightTagFn(name)
+		return m.CreateLightweightTagFn(ctx, name)
 	}
 	return nil
 }
 
 // CreateSignedTag implements core.GitTagOperations.
-func (m *MockGitTagOperations) CreateSignedTag(name, message, keyID string) error {
+func (m *MockGitTagOperations) CreateSignedTag(ctx context.Context, name, message, keyID string) error {
 	if m.CreateSignedTagFn != nil {
-		return m.CreateSignedTagFn(name, message, keyID)
+		return m.CreateSignedTagFn(ctx, name, message, keyID)
 	}
 	return nil
 }
 
 // TagExists implements core.GitTagOperations.
-func (m *MockGitTagOperations) TagExists(name string) (bool, error) {
+func (m *MockGitTagOperations) TagExists(ctx context.Context, name string) (bool, error) {
 	if m.TagExistsFn != nil {
-		return m.TagExistsFn(name)
+		return m.TagExistsFn(ctx, name)
 	}
 	return false, nil
 }
 
 // GetLatestTag implements core.GitTagOperations.
-func (m *MockGitTagOperations) GetLatestTag() (string, error) {
+func (m *MockGitTagOperations) GetLatestTag(ctx context.Context) (string, error) {
 	if m.GetLatestTagFn != nil {
-		return m.GetLatestTagFn()
+		return m.GetLatestTagFn(ctx)
 	}
 	return "", nil
 }
 
 // PushTag implements core.GitTagOperations.
-func (m *MockGitTagOperations) PushTag(name string) error {
+func (m *MockGitTagOperations) PushTag(ctx context.Context, name string) error {
 	if m.PushTagFn != nil {
-		return m.PushTagFn(name)
+		return m.PushTagFn(ctx, name)
 	}
 	return nil
 }
 
 // ListTags implements core.GitTagOperations.
-func (m *MockGitTagOperations) ListTags(pattern string) ([]string, error) {
+func (m *MockGitTagOperations) ListTags(ctx context.Context, pattern string) ([]string, error) {
 	if m.ListTagsFn != nil {
-		return m.ListTagsFn(pattern)
+		return m.ListTagsFn(ctx, pattern)
 	}
 	return []string{}, nil
 }
 
 // DeleteTag implements core.GitTagOperations.
-func (m *MockGitTagOperations) DeleteTag(name string) error {
+func (m *MockGitTagOperations) DeleteTag(ctx context.Context, name string) error {
 	if m.DeleteTagFn != nil {
-		return m.DeleteTagFn(name)
+		return m.DeleteTagFn(ctx, name)
 	}
 	return nil
 }
 
 // DeleteRemoteTag implements core.GitTagOperations.
-func (m *MockGitTagOperations) DeleteRemoteTag(name string) error {
+func (m *MockGitTagOperations) DeleteRemoteTag(ctx context.Context, name string) error {
 	if m.DeleteRemoteTagFn != nil {
-		return m.DeleteRemoteTagFn(name)
+		return m.DeleteRemoteTagFn(ctx, name)
 	}
 	return nil
 }

--- a/internal/plugins/tagmanager/plugin.go
+++ b/internal/plugins/tagmanager/plugin.go
@@ -1,6 +1,7 @@
 package tagmanager
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/indaco/sley/internal/core"
@@ -27,6 +28,15 @@ type TagManager interface {
 
 	// FormatTagName formats a version as a tag name.
 	FormatTagName(version semver.SemVersion) string
+
+	// IsAutoCreateEnabled returns whether the plugin is enabled with auto-create on.
+	IsAutoCreateEnabled() bool
+
+	// GetConfig returns the plugin configuration.
+	GetConfig() *Config
+
+	// CommitChanges stages modified files and creates a commit before tagging.
+	CommitChanges(version semver.SemVersion, extraFiles []string) error
 }
 
 // Config holds configuration for the tag manager plugin.
@@ -158,27 +168,28 @@ func (p *TagManagerPlugin) CreateTag(version semver.SemVersion, message string) 
 	}
 
 	// Create the tag based on configuration
+	ctx := context.TODO()
 	switch {
 	case p.config.Sign:
 		// GPG-signed tag (implies annotated)
-		if err := p.gitOps.CreateSignedTag(tagName, message, p.config.SigningKey); err != nil {
+		if err := p.gitOps.CreateSignedTag(ctx, tagName, message, p.config.SigningKey); err != nil {
 			return fmt.Errorf("failed to create signed tag: %w", err)
 		}
 	case p.config.Annotate:
 		// Annotated tag (not signed)
-		if err := p.gitOps.CreateAnnotatedTag(tagName, message); err != nil {
+		if err := p.gitOps.CreateAnnotatedTag(ctx, tagName, message); err != nil {
 			return fmt.Errorf("failed to create annotated tag: %w", err)
 		}
 	default:
 		// Lightweight tag (no message)
-		if err := p.gitOps.CreateLightweightTag(tagName); err != nil {
+		if err := p.gitOps.CreateLightweightTag(ctx, tagName); err != nil {
 			return fmt.Errorf("failed to create lightweight tag: %w", err)
 		}
 	}
 
 	// Optionally push the tag
 	if p.config.Push {
-		if err := p.gitOps.PushTag(tagName); err != nil {
+		if err := p.gitOps.PushTag(ctx, tagName); err != nil {
 			return fmt.Errorf("failed to push tag: %w", err)
 		}
 	}
@@ -199,12 +210,12 @@ func (p *TagManagerPlugin) FormatTagMessage(version semver.SemVersion) string {
 // TagExists checks if a tag for the given version already exists.
 func (p *TagManagerPlugin) TagExists(version semver.SemVersion) (bool, error) {
 	tagName := p.FormatTagName(version)
-	return p.gitOps.TagExists(tagName)
+	return p.gitOps.TagExists(context.TODO(), tagName)
 }
 
 // GetLatestTag returns the latest semver tag from git.
 func (p *TagManagerPlugin) GetLatestTag() (semver.SemVersion, error) {
-	tag, err := p.gitOps.GetLatestTag()
+	tag, err := p.gitOps.GetLatestTag(context.TODO())
 	if err != nil {
 		return semver.SemVersion{}, err
 	}
@@ -252,7 +263,8 @@ func (p *TagManagerPlugin) CommitChanges(version semver.SemVersion, extraFiles [
 	filesToStage = append(filesToStage, extraFiles...)
 
 	// Also detect any other modified files via git status
-	modified, err := p.commitOps.GetModifiedFiles()
+	ctx := context.TODO()
+	modified, err := p.commitOps.GetModifiedFiles(ctx)
 	if err != nil {
 		return fmt.Errorf("failed to detect modified files: %w", err)
 	}
@@ -266,7 +278,7 @@ func (p *TagManagerPlugin) CommitChanges(version semver.SemVersion, extraFiles [
 	}
 
 	// Stage files
-	if err := p.commitOps.StageFiles(filesToStage...); err != nil {
+	if err := p.commitOps.StageFiles(ctx, filesToStage...); err != nil {
 		return fmt.Errorf("failed to stage files: %w", err)
 	}
 
@@ -279,7 +291,7 @@ func (p *TagManagerPlugin) CommitChanges(version semver.SemVersion, extraFiles [
 	message := FormatMessage(template, data)
 
 	// Create commit
-	if err := p.commitOps.Commit(message); err != nil {
+	if err := p.commitOps.Commit(ctx, message); err != nil {
 		return fmt.Errorf("failed to commit: %w", err)
 	}
 

--- a/internal/plugins/tagmanager/plugin_test.go
+++ b/internal/plugins/tagmanager/plugin_test.go
@@ -1,6 +1,7 @@
 package tagmanager
 
 import (
+	"context"
 	"errors"
 	"testing"
 
@@ -76,14 +77,14 @@ func TestTagManagerPlugin_TagExists(t *testing.T) {
 	tests := []struct {
 		name    string
 		version semver.SemVersion
-		mockFn  func(string) (bool, error)
+		mockFn  func(ctx context.Context, name string) (bool, error)
 		want    bool
 		wantErr bool
 	}{
 		{
 			name:    "tag exists",
 			version: semver.SemVersion{Major: 1, Minor: 0, Patch: 0},
-			mockFn: func(name string) (bool, error) {
+			mockFn: func(ctx context.Context, name string) (bool, error) {
 				return true, nil
 			},
 			want:    true,
@@ -92,7 +93,7 @@ func TestTagManagerPlugin_TagExists(t *testing.T) {
 		{
 			name:    "tag does not exist",
 			version: semver.SemVersion{Major: 2, Minor: 0, Patch: 0},
-			mockFn: func(name string) (bool, error) {
+			mockFn: func(ctx context.Context, name string) (bool, error) {
 				return false, nil
 			},
 			want:    false,
@@ -101,7 +102,7 @@ func TestTagManagerPlugin_TagExists(t *testing.T) {
 		{
 			name:    "error checking tag",
 			version: semver.SemVersion{Major: 3, Minor: 0, Patch: 0},
-			mockFn: func(name string) (bool, error) {
+			mockFn: func(ctx context.Context, name string) (bool, error) {
 				return false, errors.New("git error")
 			},
 			want:    false,
@@ -152,7 +153,7 @@ func TestTagManagerPlugin_ValidateTagAvailable(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			mockOps := &MockGitTagOperations{
-				TagExistsFn: func(name string) (bool, error) {
+				TagExistsFn: func(ctx context.Context, name string) (bool, error) {
 					return tt.exists, nil
 				},
 			}
@@ -231,18 +232,18 @@ func TestTagManagerPlugin_CreateTag(t *testing.T) {
 			pushCalled := false
 
 			mockOps := &MockGitTagOperations{
-				TagExistsFn: func(name string) (bool, error) {
+				TagExistsFn: func(ctx context.Context, name string) (bool, error) {
 					return tt.tagExists, nil
 				},
-				CreateAnnotatedTagFn: func(name, msg string) error {
+				CreateAnnotatedTagFn: func(ctx context.Context, name, msg string) error {
 					annotatedCalled = true
 					return tt.createErr
 				},
-				CreateLightweightTagFn: func(name string) error {
+				CreateLightweightTagFn: func(ctx context.Context, name string) error {
 					lightweightCalled = true
 					return tt.createErr
 				},
-				PushTagFn: func(name string) error {
+				PushTagFn: func(ctx context.Context, name string) error {
 					pushCalled = true
 					return tt.pushErr
 				},
@@ -311,7 +312,7 @@ func TestTagManagerPlugin_GetLatestTag(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			mockOps := &MockGitTagOperations{
-				GetLatestTagFn: func() (string, error) {
+				GetLatestTagFn: func(ctx context.Context) (string, error) {
 					return tt.mockTag, tt.mockErr
 				},
 			}
@@ -412,7 +413,7 @@ func TestTagManagerPlugin_GetConfig(t *testing.T) {
 
 func TestTagManagerPlugin_ValidateTagAvailable_Error(t *testing.T) {
 	mockOps := &MockGitTagOperations{
-		TagExistsFn: func(name string) (bool, error) {
+		TagExistsFn: func(ctx context.Context, name string) (bool, error) {
 			return false, errors.New("git error")
 		},
 	}
@@ -427,13 +428,13 @@ func TestTagManagerPlugin_ValidateTagAvailable_Error(t *testing.T) {
 
 func TestTagManagerPlugin_CreateTag_PushError(t *testing.T) {
 	mockOps := &MockGitTagOperations{
-		TagExistsFn: func(name string) (bool, error) {
+		TagExistsFn: func(ctx context.Context, name string) (bool, error) {
 			return false, nil
 		},
-		CreateAnnotatedTagFn: func(name, msg string) error {
+		CreateAnnotatedTagFn: func(ctx context.Context, name, msg string) error {
 			return nil
 		},
-		PushTagFn: func(name string) error {
+		PushTagFn: func(ctx context.Context, name string) error {
 			return errors.New("push failed")
 		},
 	}
@@ -660,10 +661,10 @@ func TestTagManagerPlugin_CreateTag_Signed(t *testing.T) {
 		var capturedKeyID string
 
 		mockOps := &MockGitTagOperations{
-			TagExistsFn: func(name string) (bool, error) {
+			TagExistsFn: func(ctx context.Context, name string) (bool, error) {
 				return false, nil
 			},
-			CreateSignedTagFn: func(name, msg, keyID string) error {
+			CreateSignedTagFn: func(ctx context.Context, name, msg, keyID string) error {
 				signedCalled = true
 				capturedMessage = msg
 				capturedKeyID = keyID
@@ -701,10 +702,10 @@ func TestTagManagerPlugin_CreateTag_Signed(t *testing.T) {
 		var capturedKeyID string
 
 		mockOps := &MockGitTagOperations{
-			TagExistsFn: func(name string) (bool, error) {
+			TagExistsFn: func(ctx context.Context, name string) (bool, error) {
 				return false, nil
 			},
-			CreateSignedTagFn: func(name, msg, keyID string) error {
+			CreateSignedTagFn: func(ctx context.Context, name, msg, keyID string) error {
 				signedCalled = true
 				capturedKeyID = keyID
 				return nil
@@ -735,10 +736,10 @@ func TestTagManagerPlugin_CreateTag_Signed(t *testing.T) {
 
 	t.Run("signed tag error", func(t *testing.T) {
 		mockOps := &MockGitTagOperations{
-			TagExistsFn: func(name string) (bool, error) {
+			TagExistsFn: func(ctx context.Context, name string) (bool, error) {
 				return false, nil
 			},
-			CreateSignedTagFn: func(name, msg, keyID string) error {
+			CreateSignedTagFn: func(ctx context.Context, name, msg, keyID string) error {
 				return errors.New("gpg signing failed")
 			},
 		}
@@ -797,10 +798,10 @@ func TestTagManagerPlugin_CreateTag_MessageTemplate(t *testing.T) {
 			var capturedMessage string
 
 			mockOps := &MockGitTagOperations{
-				TagExistsFn: func(name string) (bool, error) {
+				TagExistsFn: func(ctx context.Context, name string) (bool, error) {
 					return false, nil
 				},
-				CreateAnnotatedTagFn: func(name, msg string) error {
+				CreateAnnotatedTagFn: func(ctx context.Context, name, msg string) error {
 					capturedMessage = msg
 					return nil
 				},
@@ -831,10 +832,10 @@ func TestTagManagerPlugin_CreateTag_ExplicitMessageOverridesTemplate(t *testing.
 	var capturedMessage string
 
 	mockOps := &MockGitTagOperations{
-		TagExistsFn: func(name string) (bool, error) {
+		TagExistsFn: func(ctx context.Context, name string) (bool, error) {
 			return false, nil
 		},
-		CreateAnnotatedTagFn: func(name, msg string) error {
+		CreateAnnotatedTagFn: func(ctx context.Context, name, msg string) error {
 			capturedMessage = msg
 			return nil
 		},
@@ -935,14 +936,14 @@ func TestTagManagerPlugin_CommitChanges_AutoDetect(t *testing.T) {
 	var stagedFiles []string
 
 	mockCommitOps := &MockGitCommitOperations{
-		GetModifiedFilesFn: func() ([]string, error) {
+		GetModifiedFilesFn: func(ctx context.Context) ([]string, error) {
 			return []string{"CHANGELOG.md", "package.json"}, nil
 		},
-		StageFilesFn: func(files ...string) error {
+		StageFilesFn: func(ctx context.Context, files ...string) error {
 			stagedFiles = files
 			return nil
 		},
-		CommitFn: func(message string) error {
+		CommitFn: func(ctx context.Context, message string) error {
 			return nil
 		},
 	}
@@ -971,14 +972,14 @@ func TestTagManagerPlugin_CommitChanges_Deduplication(t *testing.T) {
 	var stagedFiles []string
 
 	mockCommitOps := &MockGitCommitOperations{
-		GetModifiedFilesFn: func() ([]string, error) {
+		GetModifiedFilesFn: func(ctx context.Context) ([]string, error) {
 			return []string{".version", "other.txt"}, nil
 		},
-		StageFilesFn: func(files ...string) error {
+		StageFilesFn: func(ctx context.Context, files ...string) error {
 			stagedFiles = files
 			return nil
 		},
-		CommitFn: func(message string) error {
+		CommitFn: func(ctx context.Context, message string) error {
 			return nil
 		},
 	}
@@ -1006,10 +1007,10 @@ func TestTagManagerPlugin_CommitChanges_Deduplication(t *testing.T) {
 
 func TestTagManagerPlugin_CommitChanges_StageError(t *testing.T) {
 	mockCommitOps := &MockGitCommitOperations{
-		GetModifiedFilesFn: func() ([]string, error) {
+		GetModifiedFilesFn: func(ctx context.Context) ([]string, error) {
 			return []string{"file.txt"}, nil
 		},
-		StageFilesFn: func(files ...string) error {
+		StageFilesFn: func(ctx context.Context, files ...string) error {
 			return errors.New("staging failed")
 		},
 	}
@@ -1029,13 +1030,13 @@ func TestTagManagerPlugin_CommitChanges_StageError(t *testing.T) {
 
 func TestTagManagerPlugin_CommitChanges_CommitError(t *testing.T) {
 	mockCommitOps := &MockGitCommitOperations{
-		GetModifiedFilesFn: func() ([]string, error) {
+		GetModifiedFilesFn: func(ctx context.Context) ([]string, error) {
 			return []string{"file.txt"}, nil
 		},
-		StageFilesFn: func(files ...string) error {
+		StageFilesFn: func(ctx context.Context, files ...string) error {
 			return nil
 		},
-		CommitFn: func(message string) error {
+		CommitFn: func(ctx context.Context, message string) error {
 			return errors.New("commit failed")
 		},
 	}
@@ -1055,7 +1056,7 @@ func TestTagManagerPlugin_CommitChanges_CommitError(t *testing.T) {
 
 func TestTagManagerPlugin_CommitChanges_GetModifiedError(t *testing.T) {
 	mockCommitOps := &MockGitCommitOperations{
-		GetModifiedFilesFn: func() ([]string, error) {
+		GetModifiedFilesFn: func(ctx context.Context) ([]string, error) {
 			return nil, errors.New("git status failed")
 		},
 	}
@@ -1078,14 +1079,14 @@ func TestTagManagerPlugin_CommitChanges_NoFilesToStage(t *testing.T) {
 	commitCalled := false
 
 	mockCommitOps := &MockGitCommitOperations{
-		GetModifiedFilesFn: func() ([]string, error) {
+		GetModifiedFilesFn: func(ctx context.Context) ([]string, error) {
 			return []string{}, nil
 		},
-		StageFilesFn: func(files ...string) error {
+		StageFilesFn: func(ctx context.Context, files ...string) error {
 			stageCalled = true
 			return nil
 		},
-		CommitFn: func(message string) error {
+		CommitFn: func(ctx context.Context, message string) error {
 			commitCalled = true
 			return nil
 		},
@@ -1115,13 +1116,13 @@ func TestTagManagerPlugin_CommitChanges_DefaultTemplate(t *testing.T) {
 	var commitMessage string
 
 	mockCommitOps := &MockGitCommitOperations{
-		GetModifiedFilesFn: func() ([]string, error) {
+		GetModifiedFilesFn: func(ctx context.Context) ([]string, error) {
 			return []string{"file.txt"}, nil
 		},
-		StageFilesFn: func(files ...string) error {
+		StageFilesFn: func(ctx context.Context, files ...string) error {
 			return nil
 		},
-		CommitFn: func(message string) error {
+		CommitFn: func(ctx context.Context, message string) error {
 			commitMessage = message
 			return nil
 		},
@@ -1149,13 +1150,13 @@ func TestTagManagerPlugin_CommitChanges_CustomTemplate(t *testing.T) {
 	var commitMessage string
 
 	mockCommitOps := &MockGitCommitOperations{
-		GetModifiedFilesFn: func() ([]string, error) {
+		GetModifiedFilesFn: func(ctx context.Context) ([]string, error) {
 			return []string{"file.txt"}, nil
 		},
-		StageFilesFn: func(files ...string) error {
+		StageFilesFn: func(ctx context.Context, files ...string) error {
 			return nil
 		},
-		CommitFn: func(message string) error {
+		CommitFn: func(ctx context.Context, message string) error {
 			commitMessage = message
 			return nil
 		},

--- a/internal/plugins/versionvalidator/plugin.go
+++ b/internal/plugins/versionvalidator/plugin.go
@@ -17,6 +17,7 @@ type VersionValidator interface {
 	Version() string
 	Validate(newVersion, previousVersion semver.SemVersion, bumpType string) error
 	ValidateSet(version semver.SemVersion) error
+	IsEnabled() bool
 }
 
 // RuleType defines the type of validation rule.


### PR DESCRIPTION
## Description

 - Add `context.Context` as the first parameter to all `GitTagOperations` and `GitCommitOperations` in `core/interfaces.go`
- Update all implementations in `tagmanager/git.go` to use `exec.CommandContext` for cancellable subprocess execution
- Promote `IsEnabled()`, `IsAutoCreateEnabled()`, `GetConfig()`, `CommitChanges()` onto plugin interfaces (`TagManager`, `VersionValidator`, `ReleaseGate`)
- Eliminate all  type assertions in `commands/bump/helpers.go` and `commands/depsync/sync.go`
- Update all mocks (`core/mocks.go`, tagmanager mock files) to match new signatures

## Related Issue

<!-- Link to related issue if any, e.g., "Fixes #123" -->

## Notes for Reviewers

<!-- Anything specific you'd like feedback on? -->
