### PR TITLE
refactor(bump): delegate single-module bumps to operations.BumpOperation

### DIFF
--- a/internal/commands/bump/bump_release_test.go
+++ b/internal/commands/bump/bump_release_test.go
@@ -103,8 +103,8 @@ func TestCLI_BumpReleaseCommand_SaveVersionFails(t *testing.T) {
 		t.Fatal("expected error due to save failure, got nil")
 	}
 
-	if !strings.Contains(err.Error(), "failed to save version") {
-		t.Errorf("expected error message to contain 'failed to save version', got: %v", err)
+	if !strings.Contains(err.Error(), "failed to write version") {
+		t.Errorf("expected error message to contain 'failed to write version', got: %v", err)
 	}
 }
 

--- a/internal/commands/bump/common.go
+++ b/internal/commands/bump/common.go
@@ -2,19 +2,17 @@ package bump
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/indaco/sley/internal/clix"
 	"github.com/indaco/sley/internal/commands/depsync"
 	"github.com/indaco/sley/internal/config"
+	"github.com/indaco/sley/internal/core"
 	"github.com/indaco/sley/internal/operations"
 	"github.com/indaco/sley/internal/plugins"
 	"github.com/indaco/sley/internal/semver"
 	"github.com/urfave/cli/v3"
 )
-
-// versionCalculator is a function that calculates the new version from the previous version.
-// It receives the previous version and returns the new version.
-type versionCalculator func(prev semver.SemVersion) semver.SemVersion
 
 // bumpParams holds all parameters needed for a bump operation.
 type bumpParams struct {
@@ -23,11 +21,12 @@ type bumpParams struct {
 	preserveMeta bool
 	skipHooks    bool
 	bumpType     string
-	versionCalc  versionCalculator
+	opBumpType   operations.BumpType
 }
 
 // executeSingleModuleBump is the unified execution pipeline for single-module bump operations.
-// It handles all common logic: validation, hooks, update, and post-actions.
+// It delegates version calculation and writing to operations.BumpOperation,
+// the same implementation used by multi-module bumps, ensuring consistent behavior.
 func executeSingleModuleBump(
 	ctx context.Context,
 	cmd *cli.Command,
@@ -41,57 +40,55 @@ func executeSingleModuleBump(
 		return err
 	}
 
-	// Read current version
-	previousVersion, err := semver.ReadVersion(execCtx.Path)
+	// Create BumpOperation - the same path used by multi-module bumps
+	fs := core.NewOSFileSystem()
+	bumper := newVersionBumper()
+	op := operations.NewBumpOperation(
+		fs, bumper, params.opBumpType,
+		params.pre, params.meta, params.preserveMeta,
+	)
+
+	// Preview: calculate new version without writing
+	result, err := op.Preview(ctx, execCtx.Path)
 	if err != nil {
 		return err
 	}
 
-	// Calculate new version using the provided calculator
-	newVersion := params.versionCalc(previousVersion)
-
-	// Apply pre-release and build metadata
-	newVersion.Build = calculateNewBuild(params.meta, params.preserveMeta, previousVersion.Build)
-
 	// Run pre-bump extension hooks first - extensions may set up state that plugins need to validate
-	if err := runPreBumpExtensionHooks(ctx, cfg, execCtx.Path, newVersion.String(), previousVersion.String(), params.bumpType, params.skipHooks); err != nil {
+	if err := runPreBumpExtensionHooks(ctx, cfg, execCtx.Path, result.NewVersion.String(), result.PreviousVersion.String(), params.bumpType, params.skipHooks); err != nil {
 		return err
 	}
 
-	// Re-read the current version in case an extension modified the .version file
-	// (e.g., an extension that fetches the latest release from GitHub and updates .version)
+	// Re-preview in case an extension modified the .version file
 	if !params.skipHooks {
-		previousVersion, err = semver.ReadVersion(execCtx.Path)
+		result, err = op.Preview(ctx, execCtx.Path)
 		if err != nil {
 			return err
 		}
-		// Recalculate the new version based on the potentially updated previous version
-		newVersion = params.versionCalc(previousVersion)
-		newVersion.Build = calculateNewBuild(params.meta, params.preserveMeta, previousVersion.Build)
 	}
 
 	// Execute all pre-bump validations after extensions have run
-	if err := executePreBumpValidations(registry, newVersion, previousVersion, params.bumpType); err != nil {
+	if err := executePreBumpValidations(registry, result.NewVersion, result.PreviousVersion, params.bumpType); err != nil {
 		return err
 	}
 
-	// Update the version file
-	if err := semver.UpdateVersion(execCtx.Path, params.bumpType, params.pre, params.meta, params.preserveMeta); err != nil {
-		return err
+	// Write the new version using BumpOperation
+	if err := op.Write(ctx, execCtx.Path, result.NewVersion); err != nil {
+		return fmt.Errorf("failed to write version: %w", err)
 	}
 
 	// Execute all post-bump actions
-	if err := executePostBumpActions(registry, newVersion, previousVersion, params.bumpType, execCtx.Path); err != nil {
+	if err := executePostBumpActions(registry, result.NewVersion, result.PreviousVersion, params.bumpType, execCtx.Path); err != nil {
 		return err
 	}
 
 	// Run post-bump extension hooks
-	if err := runPostBumpExtensionHooks(ctx, cfg, execCtx.Path, previousVersion.String(), params.bumpType, params.skipHooks); err != nil {
+	if err := runPostBumpExtensionHooks(ctx, cfg, execCtx.Path, result.PreviousVersion.String(), params.bumpType, params.skipHooks); err != nil {
 		return err
 	}
 
 	// Commit (if auto-commit enabled) and create tag after successful bump
-	return commitAndTagAfterBump(registry, newVersion, params.bumpType, execCtx.Path)
+	return commitAndTagAfterBump(registry, result.NewVersion, params.bumpType, execCtx.Path)
 }
 
 // executePreBumpValidations runs all validation checks before performing a bump.
@@ -135,50 +132,15 @@ func executePostBumpActions(registry *plugins.PluginRegistry, newVersion, previo
 	return recordAuditLogEntry(registry, newVersion, previousVersion, bumpType)
 }
 
-// makePatchCalculator returns a version calculator for patch bumps.
-func makePatchCalculator(pre, meta string, preserveMeta bool) versionCalculator {
-	return func(prev semver.SemVersion) semver.SemVersion {
-		next := prev
-		next.Patch++
-		next.PreRelease = pre
-		next.Build = calculateNewBuild(meta, preserveMeta, prev.Build)
-		return next
-	}
-}
-
-// makeMinorCalculator returns a version calculator for minor bumps.
-func makeMinorCalculator(pre, meta string, preserveMeta bool) versionCalculator {
-	return func(prev semver.SemVersion) semver.SemVersion {
-		next := prev
-		next.Minor++
-		next.Patch = 0
-		next.PreRelease = pre
-		next.Build = calculateNewBuild(meta, preserveMeta, prev.Build)
-		return next
-	}
-}
-
-// makeMajorCalculator returns a version calculator for major bumps.
-func makeMajorCalculator(pre, meta string, preserveMeta bool) versionCalculator {
-	return func(prev semver.SemVersion) semver.SemVersion {
-		next := prev
-		next.Major++
-		next.Minor = 0
-		next.Patch = 0
-		next.PreRelease = pre
-		next.Build = calculateNewBuild(meta, preserveMeta, prev.Build)
-		return next
-	}
-}
-
 // extractBumpParams extracts common bump parameters from CLI command.
-func extractBumpParams(cmd *cli.Command, bumpType string) bumpParams {
+func extractBumpParams(cmd *cli.Command, bumpType string, opBumpType operations.BumpType) bumpParams {
 	return bumpParams{
 		pre:          cmd.String("pre"),
 		meta:         cmd.String("meta"),
 		preserveMeta: cmd.Bool("preserve-meta"),
 		skipHooks:    cmd.Bool("skip-hooks"),
 		bumpType:     bumpType,
+		opBumpType:   opBumpType,
 	}
 }
 
@@ -190,7 +152,6 @@ func executeStandardBump(
 	cfg *config.Config,
 	registry *plugins.PluginRegistry,
 	params bumpParams,
-	multiModuleOp operations.BumpType,
 ) error {
 	execCtx, err := clix.GetExecutionContext(ctx, cmd, cfg)
 	if err != nil {
@@ -199,7 +160,7 @@ func executeStandardBump(
 
 	if !execCtx.IsSingleModule() {
 		// Multi-module mode delegates to runMultiModuleBump
-		return runMultiModuleBump(ctx, cmd, execCtx, registry, multiModuleOp, params.pre, params.meta, params.preserveMeta)
+		return runMultiModuleBump(ctx, cmd, execCtx, registry, params.opBumpType, params.pre, params.meta, params.preserveMeta)
 	}
 
 	// Single-module mode uses the unified executor

--- a/internal/commands/bump/major.go
+++ b/internal/commands/bump/major.go
@@ -34,8 +34,7 @@ func runBumpMajor(ctx context.Context, cmd *cli.Command, cfg *config.Config, reg
 		return err
 	}
 
-	params := extractBumpParams(cmd, "major")
-	params.versionCalc = makeMajorCalculator(params.pre, params.meta, params.preserveMeta)
+	params := extractBumpParams(cmd, "major", operations.BumpMajor)
 
-	return executeStandardBump(ctx, cmd, cfg, registry, params, operations.BumpMajor)
+	return executeStandardBump(ctx, cmd, cfg, registry, params)
 }

--- a/internal/commands/bump/minor.go
+++ b/internal/commands/bump/minor.go
@@ -34,8 +34,7 @@ func runBumpMinor(ctx context.Context, cmd *cli.Command, cfg *config.Config, reg
 		return err
 	}
 
-	params := extractBumpParams(cmd, "minor")
-	params.versionCalc = makeMinorCalculator(params.pre, params.meta, params.preserveMeta)
+	params := extractBumpParams(cmd, "minor", operations.BumpMinor)
 
-	return executeStandardBump(ctx, cmd, cfg, registry, params, operations.BumpMinor)
+	return executeStandardBump(ctx, cmd, cfg, registry, params)
 }

--- a/internal/commands/bump/patch.go
+++ b/internal/commands/bump/patch.go
@@ -34,8 +34,7 @@ func runBumpPatch(ctx context.Context, cmd *cli.Command, cfg *config.Config, reg
 		return err
 	}
 
-	params := extractBumpParams(cmd, "patch")
-	params.versionCalc = makePatchCalculator(params.pre, params.meta, params.preserveMeta)
+	params := extractBumpParams(cmd, "patch", operations.BumpPatch)
 
-	return executeStandardBump(ctx, cmd, cfg, registry, params, operations.BumpPatch)
+	return executeStandardBump(ctx, cmd, cfg, registry, params)
 }

--- a/internal/commands/bump/pre.go
+++ b/internal/commands/bump/pre.go
@@ -2,7 +2,6 @@ package bump
 
 import (
 	"context"
-	"fmt"
 
 	"github.com/indaco/sley/internal/cliflags"
 	"github.com/indaco/sley/internal/clix"
@@ -10,7 +9,6 @@ import (
 	"github.com/indaco/sley/internal/hooks"
 	"github.com/indaco/sley/internal/operations"
 	"github.com/indaco/sley/internal/plugins"
-	"github.com/indaco/sley/internal/semver"
 	"github.com/urfave/cli/v3"
 )
 
@@ -64,98 +62,18 @@ func runBumpPre(ctx context.Context, cmd *cli.Command, cfg *config.Config, regis
 		return err
 	}
 
-	// Handle single-module mode
-	if execCtx.IsSingleModule() {
-		return runSingleModulePreBump(ctx, cmd, cfg, registry, execCtx, label, meta, isPreserveMeta, isSkipHooks)
+	if !execCtx.IsSingleModule() {
+		return runMultiModuleBump(ctx, cmd, execCtx, registry, operations.BumpPre, label, meta, isPreserveMeta)
 	}
 
-	// Handle multi-module mode
-	// For pre-release bump, the label is used as the pre-release identifier
-	return runMultiModuleBump(ctx, cmd, execCtx, registry, operations.BumpPre, label, meta, isPreserveMeta)
-}
-
-// runSingleModulePreBump handles pre-release bump for single-module mode.
-func runSingleModulePreBump(ctx context.Context, cmd *cli.Command, cfg *config.Config, registry *plugins.PluginRegistry, execCtx *clix.ExecutionContext, label, meta string, isPreserveMeta, isSkipHooks bool) error {
-	if _, err := clix.FromCommandFn(cmd); err != nil {
-		return err
+	// Single-module: use the unified path via BumpOperation
+	params := bumpParams{
+		pre:          label,
+		meta:         meta,
+		preserveMeta: isPreserveMeta,
+		skipHooks:    isSkipHooks,
+		bumpType:     "pre",
+		opBumpType:   operations.BumpPre,
 	}
-
-	previousVersion, err := semver.ReadVersion(execCtx.Path)
-	if err != nil {
-		return err
-	}
-
-	// Calculate new version
-	newVersion := previousVersion
-	if label != "" {
-		newVersion.PreRelease = semver.IncrementPreRelease(previousVersion.PreRelease, label)
-	} else {
-		if previousVersion.PreRelease == "" {
-			return fmt.Errorf("current version has no pre-release; use --label to specify one")
-		}
-		base := extractPreReleaseBase(previousVersion.PreRelease)
-		newVersion.PreRelease = semver.IncrementPreRelease(previousVersion.PreRelease, base)
-	}
-	newVersion.Build = calculateNewBuild(meta, isPreserveMeta, previousVersion.Build)
-
-	// Execute all pre-bump validations
-	if err := executePreBumpValidations(registry, newVersion, previousVersion, "pre"); err != nil {
-		return err
-	}
-
-	if err := runPreBumpExtensionHooks(ctx, cfg, execCtx.Path, newVersion.String(), previousVersion.String(), "pre", isSkipHooks); err != nil {
-		return err
-	}
-
-	if err := semver.UpdatePreRelease(execCtx.Path, label, meta, isPreserveMeta); err != nil {
-		return err
-	}
-
-	// Execute all post-bump actions
-	if err := executePostBumpActions(registry, newVersion, previousVersion, "pre", execCtx.Path); err != nil {
-		return err
-	}
-
-	if err := runPostBumpExtensionHooks(ctx, cfg, execCtx.Path, previousVersion.String(), "pre", isSkipHooks); err != nil {
-		return err
-	}
-
-	// Create tag after successful bump
-	return createTagAfterBump(registry, newVersion, "pre")
-}
-
-// extractPreReleaseBase extracts the base label from a pre-release string.
-// e.g., "rc.1" -> "rc", "beta.2" -> "beta", "alpha" -> "alpha", "rc1" -> "rc"
-func extractPreReleaseBase(pre string) string {
-	// First, check for dot followed by a number
-	for i := len(pre) - 1; i >= 0; i-- {
-		if pre[i] == '.' {
-			// Check if everything after the dot is numeric
-			suffix := pre[i+1:]
-			isNumeric := true
-			for _, c := range suffix {
-				if c < '0' || c > '9' {
-					isNumeric = false
-					break
-				}
-			}
-			if isNumeric && len(suffix) > 0 {
-				return pre[:i]
-			}
-		}
-	}
-
-	// Check for trailing digits without dot (e.g., "rc1" -> "rc")
-	lastNonDigit := -1
-	for i := len(pre) - 1; i >= 0; i-- {
-		if pre[i] < '0' || pre[i] > '9' {
-			lastNonDigit = i
-			break
-		}
-	}
-	if lastNonDigit >= 0 && lastNonDigit < len(pre)-1 {
-		return pre[:lastNonDigit+1]
-	}
-
-	return pre
+	return executeSingleModuleBump(ctx, cmd, cfg, registry, execCtx, params)
 }

--- a/internal/commands/bump/release.go
+++ b/internal/commands/bump/release.go
@@ -2,15 +2,12 @@ package bump
 
 import (
 	"context"
-	"fmt"
 
 	"github.com/indaco/sley/internal/clix"
 	"github.com/indaco/sley/internal/config"
 	"github.com/indaco/sley/internal/hooks"
 	"github.com/indaco/sley/internal/operations"
 	"github.com/indaco/sley/internal/plugins"
-	"github.com/indaco/sley/internal/printer"
-	"github.com/indaco/sley/internal/semver"
 	"github.com/urfave/cli/v3"
 )
 
@@ -48,67 +45,16 @@ func runBumpRelease(ctx context.Context, cmd *cli.Command, cfg *config.Config, r
 		return err
 	}
 
-	// Handle single-module mode
-	if execCtx.IsSingleModule() {
-		return runSingleModuleRelease(ctx, cmd, cfg, registry, execCtx.Path, isPreserveMeta, isSkipHooks)
+	if !execCtx.IsSingleModule() {
+		return runMultiModuleBump(ctx, cmd, execCtx, registry, operations.BumpRelease, "", "", isPreserveMeta)
 	}
 
-	// Handle multi-module mode
-	// For release, we pass empty pre-release and metadata, preserveMetadata flag controls the behavior
-	meta := ""
-	if isPreserveMeta {
-		// The BumpOperation will handle preserve-meta correctly
-		meta = ""
+	// Single-module: use the unified path
+	params := bumpParams{
+		preserveMeta: isPreserveMeta,
+		skipHooks:    isSkipHooks,
+		bumpType:     "release",
+		opBumpType:   operations.BumpRelease,
 	}
-	return runMultiModuleBump(ctx, cmd, execCtx, registry, operations.BumpRelease, "", meta, isPreserveMeta)
-}
-
-// runSingleModuleRelease handles the single-module release operation.
-func runSingleModuleRelease(ctx context.Context, cmd *cli.Command, cfg *config.Config, registry *plugins.PluginRegistry, path string, isPreserveMeta, skipHooks bool) error {
-	if _, err := clix.FromCommandFn(cmd); err != nil {
-		return err
-	}
-
-	previousVersion, err := semver.ReadVersion(path)
-	if err != nil {
-		return fmt.Errorf("failed to read version: %w", err)
-	}
-
-	newVersion := previousVersion
-	newVersion.PreRelease = ""
-	if !isPreserveMeta {
-		newVersion.Build = ""
-	}
-
-	// Execute all pre-bump validations
-	if err := executePreBumpValidations(registry, newVersion, previousVersion, "release"); err != nil {
-		return err
-	}
-
-	// Run pre-bump extension hooks
-	if err := runPreBumpExtensionHooks(ctx, cfg, path, newVersion.String(), previousVersion.String(), "release", skipHooks); err != nil {
-		return err
-	}
-
-	if err := semver.SaveVersion(path, newVersion); err != nil {
-		return fmt.Errorf("failed to save version: %w", err)
-	}
-
-	// Execute all post-bump actions
-	if err := executePostBumpActions(registry, newVersion, previousVersion, "release", path); err != nil {
-		return err
-	}
-
-	// Run post-bump extension hooks
-	if err := runPostBumpExtensionHooks(ctx, cfg, path, previousVersion.String(), "release", skipHooks); err != nil {
-		return err
-	}
-
-	// Create tag after successful bump
-	if err := createTagAfterBump(registry, newVersion, "release"); err != nil {
-		return err
-	}
-
-	printer.PrintSuccess(fmt.Sprintf("Promoted to release version: %s", newVersion.String()))
-	return nil
+	return executeSingleModuleBump(ctx, cmd, cfg, registry, execCtx, params)
 }

--- a/internal/operations/bump.go
+++ b/internal/operations/bump.go
@@ -170,7 +170,7 @@ func (op *BumpOperation) calculatePreRelease(current semver.SemVersion) (string,
 		return semver.IncrementPreRelease(current.PreRelease, op.preRelease), nil
 	}
 	if current.PreRelease != "" {
-		base := extractPreReleaseBase(current.PreRelease)
+		base := semver.ExtractPreReleaseBase(current.PreRelease)
 		return semver.IncrementPreRelease(current.PreRelease, base), nil
 	}
 	return "", fmt.Errorf("current version has no pre-release; use --label to specify one")
@@ -198,38 +198,52 @@ func (op *BumpOperation) Name() string {
 	return fmt.Sprintf("bump %s", op.bumpType)
 }
 
-// extractPreReleaseBase extracts the base label from a pre-release string.
-// e.g., "rc.1" -> "rc", "beta.2" -> "beta", "alpha" -> "alpha", "rc1" -> "rc"
-func extractPreReleaseBase(pre string) string {
-	// First, check for dot followed by a number
-	for i := len(pre) - 1; i >= 0; i-- {
-		if pre[i] == '.' {
-			// Check if everything after the dot is numeric
-			suffix := pre[i+1:]
-			isNumeric := true
-			for _, c := range suffix {
-				if c < '0' || c > '9' {
-					isNumeric = false
-					break
-				}
-			}
-			if isNumeric && len(suffix) > 0 {
-				return pre[:i]
-			}
-		}
+// BumpResult holds the result of a version bump calculation.
+type BumpResult struct {
+	PreviousVersion semver.SemVersion
+	NewVersion      semver.SemVersion
+}
+
+// Preview calculates the new version without writing it.
+// This allows callers to inspect the result for hooks and validation
+// before committing the write via Write().
+func (op *BumpOperation) Preview(ctx context.Context, path string) (BumpResult, error) {
+	select {
+	case <-ctx.Done():
+		return BumpResult{}, ctx.Err()
+	default:
 	}
 
-	// Check for trailing digits without dot (e.g., "rc1" -> "rc")
-	lastNonDigit := -1
-	for i := len(pre) - 1; i >= 0; i-- {
-		if pre[i] < '0' || pre[i] > '9' {
-			lastNonDigit = i
-			break
-		}
-	}
-	if lastNonDigit >= 0 && lastNonDigit < len(pre)-1 {
-		return pre[:lastNonDigit+1]
+	vm := semver.NewVersionManager(op.fs, nil)
+	currentVer, err := vm.Read(ctx, path)
+	if err != nil {
+		return BumpResult{}, fmt.Errorf("failed to read version from %s: %w", path, err)
 	}
 
-	return pre
+	newVer, err := op.calculateNewVersion(currentVer)
+	if err != nil {
+		return BumpResult{}, err
+	}
+
+	if op.bumpType != BumpPre {
+		op.applyPreReleaseAndMetadata(&newVer, currentVer)
+	}
+
+	return BumpResult{
+		PreviousVersion: currentVer,
+		NewVersion:      newVer,
+	}, nil
+}
+
+// Write saves the given version to the specified path.
+// Used after Preview() when the caller has completed hooks and validation.
+func (op *BumpOperation) Write(ctx context.Context, path string, version semver.SemVersion) error {
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	default:
+	}
+
+	vm := semver.NewVersionManager(op.fs, nil)
+	return vm.Save(ctx, path, version)
 }

--- a/internal/operations/bump_test.go
+++ b/internal/operations/bump_test.go
@@ -723,10 +723,150 @@ func TestExtractPreReleaseBase(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.input, func(t *testing.T) {
-			result := extractPreReleaseBase(tt.input)
+			result := semver.ExtractPreReleaseBase(tt.input)
 			if result != tt.expected {
-				t.Errorf("extractPreReleaseBase(%q) = %q, want %q", tt.input, result, tt.expected)
+				t.Errorf("ExtractPreReleaseBase(%q) = %q, want %q", tt.input, result, tt.expected)
 			}
 		})
+	}
+}
+
+func TestBumpOperation_Preview_ReturnsVersionsWithoutWriting(t *testing.T) {
+	fs := core.NewMockFileSystem()
+	fs.SetFile("/test/.version", []byte("1.2.3\n"))
+
+	op := NewBumpOperation(fs, semver.NewDefaultBumper(), BumpPatch, "", "", false)
+
+	ctx := context.Background()
+	result, err := op.Preview(ctx, "/test/.version")
+	if err != nil {
+		t.Fatalf("Preview failed: %v", err)
+	}
+
+	if result.PreviousVersion.String() != "1.2.3" {
+		t.Errorf("PreviousVersion = %q, want %q", result.PreviousVersion.String(), "1.2.3")
+	}
+	if result.NewVersion.String() != "1.2.4" {
+		t.Errorf("NewVersion = %q, want %q", result.NewVersion.String(), "1.2.4")
+	}
+
+	// Verify file was NOT modified
+	data, ok := fs.GetFile("/test/.version")
+	if !ok {
+		t.Fatal("version file not found")
+	}
+	if string(data) != "1.2.3\n" {
+		t.Errorf("file was modified by Preview: got %q, want %q", string(data), "1.2.3\n")
+	}
+}
+
+func TestBumpOperation_Preview_Minor(t *testing.T) {
+	fs := core.NewMockFileSystem()
+	fs.SetFile("/test/.version", []byte("1.2.3\n"))
+
+	op := NewBumpOperation(fs, semver.NewDefaultBumper(), BumpMinor, "", "", false)
+
+	result, err := op.Preview(context.Background(), "/test/.version")
+	if err != nil {
+		t.Fatalf("Preview failed: %v", err)
+	}
+
+	if result.NewVersion.String() != "1.3.0" {
+		t.Errorf("NewVersion = %q, want %q", result.NewVersion.String(), "1.3.0")
+	}
+}
+
+func TestBumpOperation_Preview_ContextCancellation(t *testing.T) {
+	fs := core.NewMockFileSystem()
+	fs.SetFile("/test/.version", []byte("1.2.3\n"))
+
+	op := NewBumpOperation(fs, semver.NewDefaultBumper(), BumpPatch, "", "", false)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	_, err := op.Preview(ctx, "/test/.version")
+	if err == nil {
+		t.Fatal("expected context cancellation error, got nil")
+	}
+}
+
+func TestBumpOperation_Preview_ReadError(t *testing.T) {
+	fs := core.NewMockFileSystem()
+
+	op := NewBumpOperation(fs, semver.NewDefaultBumper(), BumpPatch, "", "", false)
+
+	_, err := op.Preview(context.Background(), "/test/.version")
+	if err == nil {
+		t.Fatal("expected read error, got nil")
+	}
+}
+
+func TestBumpOperation_Write(t *testing.T) {
+	fs := core.NewMockFileSystem()
+	fs.SetFile("/test/.version", []byte("1.2.3\n"))
+
+	op := NewBumpOperation(fs, semver.NewDefaultBumper(), BumpPatch, "", "", false)
+	newVer := semver.SemVersion{Major: 1, Minor: 2, Patch: 4}
+
+	err := op.Write(context.Background(), "/test/.version", newVer)
+	if err != nil {
+		t.Fatalf("Write failed: %v", err)
+	}
+
+	data, ok := fs.GetFile("/test/.version")
+	if !ok {
+		t.Fatal("version file not found")
+	}
+	if string(data) != "1.2.4\n" {
+		t.Errorf("version = %q, want %q", string(data), "1.2.4\n")
+	}
+}
+
+func TestBumpOperation_Write_ContextCancellation(t *testing.T) {
+	fs := core.NewMockFileSystem()
+	fs.SetFile("/test/.version", []byte("1.2.3\n"))
+
+	op := NewBumpOperation(fs, semver.NewDefaultBumper(), BumpPatch, "", "", false)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	err := op.Write(ctx, "/test/.version", semver.SemVersion{Major: 1, Minor: 2, Patch: 4})
+	if err == nil {
+		t.Fatal("expected context cancellation error, got nil")
+	}
+}
+
+func TestBumpOperation_PreviewThenWrite_EqualsExecute(t *testing.T) {
+	fs1 := core.NewMockFileSystem()
+	fs1.SetFile("/test/.version", []byte("1.2.3\n"))
+
+	fs2 := core.NewMockFileSystem()
+	fs2.SetFile("/test/.version", []byte("1.2.3\n"))
+
+	ctx := context.Background()
+
+	// Path 1: Preview + Write
+	op1 := NewBumpOperation(fs1, semver.NewDefaultBumper(), BumpMinor, "alpha", "build.1", false)
+	result, err := op1.Preview(ctx, "/test/.version")
+	if err != nil {
+		t.Fatalf("Preview failed: %v", err)
+	}
+	if err := op1.Write(ctx, "/test/.version", result.NewVersion); err != nil {
+		t.Fatalf("Write failed: %v", err)
+	}
+
+	// Path 2: Execute
+	op2 := NewBumpOperation(fs2, semver.NewDefaultBumper(), BumpMinor, "alpha", "build.1", false)
+	mod := &workspace.Module{Name: "test", Path: "/test/.version"}
+	if err := op2.Execute(ctx, mod); err != nil {
+		t.Fatalf("Execute failed: %v", err)
+	}
+
+	data1, _ := fs1.GetFile("/test/.version")
+	data2, _ := fs2.GetFile("/test/.version")
+	if string(data1) != string(data2) {
+		t.Errorf("Preview+Write = %q, Execute = %q", string(data1), string(data2))
 	}
 }

--- a/internal/semver/manager.go
+++ b/internal/semver/manager.go
@@ -169,7 +169,7 @@ func (m *VersionManager) UpdatePreRelease(ctx context.Context, path string, labe
 			return fmt.Errorf("current version has no pre-release; use --label to specify one")
 		}
 		// Extract base label and increment
-		base := extractPreReleaseBase(version.PreRelease)
+		base := ExtractPreReleaseBase(version.PreRelease)
 		version.PreRelease = IncrementPreRelease(version.PreRelease, base)
 	}
 
@@ -182,9 +182,9 @@ func (m *VersionManager) UpdatePreRelease(ctx context.Context, path string, labe
 	return m.Save(ctx, path, version)
 }
 
-// extractPreReleaseBase extracts the base label from a pre-release string.
+// ExtractPreReleaseBase extracts the base label from a pre-release string.
 // e.g., "rc.1" -> "rc", "beta.2" -> "beta", "alpha" -> "alpha", "rc1" -> "rc"
-func extractPreReleaseBase(pre string) string {
+func ExtractPreReleaseBase(pre string) string {
 	// First, check for dot followed by a number
 	for i := len(pre) - 1; i >= 0; i-- {
 		if pre[i] == '.' {


### PR DESCRIPTION
## Description

Unify the dual bump logic paths. Single-module bumps now delegate to `operations.BumpOperation` instead of maintaining separate version in `commands/bump/common.go`.

This removes the `versionCalculator` type, `makePatchCalculator`/`makeMinorCalculator`/`makeMajorCalculator`, and duplicate `extractPreReleaseBase`, consolidating all bump logic through the operations package.

<!-- What does this PR do? -->

## Related Issue

- None

## Notes for Reviewers

- `BumpResult` struct with `Preview()` and `Write()` added to `operations.BumpOperation`
- `ExtractPreReleaseBase` exported from `semver/manager.go` as the canonical location
- `pre.go` and `release.go` simplified by delegating to the unified path
