### PR TITLE
fix(changelog): fix KaC ordering, safer delimiter, and per-module changelog paths

### DIFF
--- a/internal/commands/bump/auto.go
+++ b/internal/commands/bump/auto.go
@@ -232,7 +232,7 @@ func runSingleModuleAuto(ctx context.Context, cmd *cli.Command, cfg *config.Conf
 	}
 
 	// Execute all post-bump actions
-	if err := executePostBumpActions(registry, next, current, "auto", path, "", ""); err != nil {
+	if err := executePostBumpActions(registry, next, current, "auto", path, "", "", false); err != nil {
 		return err
 	}
 

--- a/internal/commands/bump/bump_plugins_test.go
+++ b/internal/commands/bump/bump_plugins_test.go
@@ -189,7 +189,7 @@ func TestGenerateChangelogAfterBump(t *testing.T) {
 	t.Run("nil generator returns nil", func(t *testing.T) {
 
 		registry := plugins.NewPluginRegistry()
-		err := generateChangelogAfterBump(registry, version, prevVersion, "major", "", "")
+		err := generateChangelogAfterBump(registry, version, prevVersion, "major", "", "", false)
 		if err != nil {
 			t.Errorf("expected nil error, got %v", err)
 		}
@@ -691,7 +691,7 @@ func TestApplyModuleChangelogDir(t *testing.T) {
 				t.Fatalf("failed to create changelog generator: %v", err)
 			}
 
-			cleanup := applyModuleChangelog(plugin, tt.modulePath, tt.modulePath, "")
+			cleanup := applyModuleChangelog(plugin, tt.modulePath, tt.modulePath, "", false)
 
 			gotCfg := plugin.GetConfig()
 			if gotCfg.ChangesDir != tt.wantChangesDir {
@@ -728,7 +728,7 @@ func TestApplyModuleChangelogDir_NonPluginType(t *testing.T) {
 	}
 
 	// Should return noop and not panic when cg is not *ChangelogGeneratorPlugin
-	cleanup := applyModuleChangelog(mock, "cobra", "cobra", "")
+	cleanup := applyModuleChangelog(mock, "cobra", "cobra", "", false)
 
 	// Config should be unchanged because the type assertion fails
 	gotCfg := mock.GetConfig()
@@ -750,7 +750,7 @@ func TestGenerateChangelogAfterBump_NilGeneratorWithModulePath(t *testing.T) {
 	prevVersion := semver.SemVersion{Major: 1, Minor: 0, Patch: 0}
 
 	// modulePath="cobra" with nil generator should return nil without panic
-	err := generateChangelogAfterBump(registry, version, prevVersion, "major", "cobra", "cobra")
+	err := generateChangelogAfterBump(registry, version, prevVersion, "major", "cobra", "cobra", false)
 	if err != nil {
 		t.Errorf("expected nil error, got %v", err)
 	}

--- a/internal/commands/bump/common.go
+++ b/internal/commands/bump/common.go
@@ -82,7 +82,7 @@ func executeSingleModuleBump(
 	}
 
 	// Execute all post-bump actions
-	if err := executePostBumpActions(registry, result.NewVersion, result.PreviousVersion, params.bumpType, execCtx.Path, "", ""); err != nil {
+	if err := executePostBumpActions(registry, result.NewVersion, result.PreviousVersion, params.bumpType, execCtx.Path, "", "", false); err != nil {
 		return err
 	}
 
@@ -122,14 +122,15 @@ func executePreBumpValidations(registry *plugins.PluginRegistry, newVersion, pre
 // bumpedPath is the .version file path (used to exclude from dep-sync output).
 // moduleName identifies the module in changelog headings (empty for single-module).
 // modulePath scopes versioned output dirs and git log (empty for root or single-module).
-func executePostBumpActions(registry *plugins.PluginRegistry, newVersion, previousVersion semver.SemVersion, bumpType, bumpedPath, moduleName, modulePath string) error {
+// independentVersioning scopes the unified changelog to the module directory.
+func executePostBumpActions(registry *plugins.PluginRegistry, newVersion, previousVersion semver.SemVersion, bumpType, bumpedPath, moduleName, modulePath string, independentVersioning bool) error {
 	// Sync dependency files after updating .version
 	if err := operations.SyncDependencies(registry, newVersion, bumpedPath); err != nil {
 		return err
 	}
 
 	// Generate changelog entry
-	if err := generateChangelogAfterBump(registry, newVersion, previousVersion, bumpType, moduleName, modulePath); err != nil {
+	if err := generateChangelogAfterBump(registry, newVersion, previousVersion, bumpType, moduleName, modulePath, independentVersioning); err != nil {
 		return err
 	}
 

--- a/internal/commands/bump/helpers.go
+++ b/internal/commands/bump/helpers.go
@@ -258,7 +258,10 @@ func validateDependencyConsistency(registry *plugins.PluginRegistry, version sem
 // moduleName is used for unified mode section headers (always set in multi-module mode).
 // modulePath scopes versioned output dirs and git log (empty for root module).
 // tagPrefix scopes tag resolution (empty for root module).
-func applyModuleChangelog(cg changeloggenerator.ChangelogGenerator, moduleName, modulePath, tagPrefix string) func() {
+// independentVersioning indicates workspace.versioning == "independent"; when true
+// and modulePath is set, the unified changelog is written to {modulePath}/CHANGELOG.md
+// instead of the shared root file, and module-name heading prefixes are skipped.
+func applyModuleChangelog(cg changeloggenerator.ChangelogGenerator, moduleName, modulePath, tagPrefix string, independentVersioning bool) func() {
 	noop := func() {}
 
 	plugin, ok := cg.(*changeloggenerator.ChangelogGeneratorPlugin)
@@ -268,9 +271,15 @@ func applyModuleChangelog(cg changeloggenerator.ChangelogGenerator, moduleName, 
 
 	cfg := cg.GetConfig()
 	originalChangesDir := cfg.ChangesDir
+	originalChangelogPath := cfg.ChangelogPath
 
-	// Always set module name for unified mode heading
-	if moduleName != "" {
+	// For independent versioning with a module path, scope the unified changelog
+	// to the module directory and skip the module-name heading prefix (each module
+	// has its own file so the prefix is redundant).
+	perModuleChangelog := independentVersioning && modulePath != ""
+
+	// Set module name for unified mode heading (skip when per-module changelog is used)
+	if moduleName != "" && !perModuleChangelog {
 		plugin.SetModuleName(moduleName)
 	}
 
@@ -281,8 +290,14 @@ func applyModuleChangelog(cg changeloggenerator.ChangelogGenerator, moduleName, 
 		plugin.SetTagPrefix(tagPrefix)
 	}
 
+	// Scope unified changelog path for independent versioning
+	if perModuleChangelog {
+		plugin.SetChangelogPath(filepath.Join(modulePath, originalChangelogPath))
+	}
+
 	return func() {
 		plugin.SetChangesDir(originalChangesDir)
+		plugin.SetChangelogPath(originalChangelogPath)
 		plugin.SetModuleName("")
 		plugin.SetModulePath("")
 		plugin.SetTagPrefix("")
@@ -307,7 +322,8 @@ func resolveTagPrefix(registry *plugins.PluginRegistry, modulePath string) strin
 // Returns nil if changelog generator is not enabled.
 // moduleName identifies the module in unified changelog headings (empty for single-module).
 // modulePath scopes versioned output dirs and git log (empty for root or single-module).
-func generateChangelogAfterBump(registry *plugins.PluginRegistry, version, _ semver.SemVersion, bumpType, moduleName, modulePath string) error {
+// independentVersioning scopes the unified changelog to the module directory.
+func generateChangelogAfterBump(registry *plugins.PluginRegistry, version, _ semver.SemVersion, bumpType, moduleName, modulePath string, independentVersioning bool) error {
 	cg := registry.GetChangelogGenerator()
 	if cg == nil {
 		return nil
@@ -321,7 +337,7 @@ func generateChangelogAfterBump(registry *plugins.PluginRegistry, version, _ sem
 	tagPrefix := resolveTagPrefix(registry, modulePath)
 
 	// Apply per-module changelog and git scoping
-	restore := applyModuleChangelog(cg, moduleName, modulePath, tagPrefix)
+	restore := applyModuleChangelog(cg, moduleName, modulePath, tagPrefix, independentVersioning)
 	defer restore()
 
 	versionStr := "v" + version.String()

--- a/internal/commands/bump/multimodule.go
+++ b/internal/commands/bump/multimodule.go
@@ -119,7 +119,8 @@ func postBumpForModule(ctx context.Context, result workspace.ExecutionResult, re
 	effectiveCfg := resolveModuleConfig(cfg, modulePath, result.Module.Dir)
 
 	// Post-bump actions (dep-sync, changelog, audit-log)
-	if err := executePostBumpActions(registry, newVer, oldVer, bumpTypeStr, result.Module.Path, moduleName, modulePath); err != nil {
+	independentVersioning := cfg != nil && cfg.Workspace != nil && cfg.Workspace.IsIndependentVersioning()
+	if err := executePostBumpActions(registry, newVer, oldVer, bumpTypeStr, result.Module.Path, moduleName, modulePath, independentVersioning); err != nil {
 		return fmt.Errorf("module %s: post-bump actions: %w", result.Module.Name, err)
 	}
 

--- a/internal/plugins/changeloggenerator/formatter_keepachangelog.go
+++ b/internal/plugins/changeloggenerator/formatter_keepachangelog.go
@@ -14,6 +14,9 @@ import (
 // - Version header: ## [version] - date (no "v" prefix, brackets around version)
 // - Standard sections: Added, Changed, Deprecated, Removed, Fixed, Security
 // - No custom icons (strict section names)
+//
+// Note: Breaking changes are placed in a separate "Breaking Changes" section,
+// which is not part of the official KaC specification but is common practice.
 type KeepAChangelogFormatter struct {
 	config *Config
 }
@@ -34,7 +37,7 @@ func (f *KeepAChangelogFormatter) FormatChangelog(
 	fmt.Fprintf(&sb, "## [%s] - %s\n\n", versionNumber, date)
 
 	// Regroup commits according to Keep a Changelog sections
-	sections := f.regroupCommits(grouped)
+	sections := f.regroupCommits(grouped, sortedKeys)
 
 	// Write sections in Keep a Changelog order
 	sectionOrder := []string{"Breaking Changes", "Added", "Changed", "Deprecated", "Removed", "Fixed", "Security"}
@@ -58,13 +61,17 @@ func (f *KeepAChangelogFormatter) FormatChangelog(
 }
 
 // regroupCommits maps conventional commit types to Keep a Changelog sections.
+// It iterates using sortedKeys to ensure deterministic ordering when commits
+// from different original groups map to the same KaC section.
 func (f *KeepAChangelogFormatter) regroupCommits(
 	grouped map[string][]*GroupedCommit,
+	sortedKeys []string,
 ) map[string][]*GroupedCommit {
 	result := make(map[string][]*GroupedCommit)
 
-	// Iterate through all grouped commits and remap them
-	for _, commits := range grouped {
+	// Iterate in stable order using sortedKeys instead of ranging the map
+	for _, key := range sortedKeys {
+		commits := grouped[key]
 		for _, commit := range commits {
 			section := f.mapTypeToSection(commit)
 			if section != "" {

--- a/internal/plugins/changeloggenerator/formatter_test.go
+++ b/internal/plugins/changeloggenerator/formatter_test.go
@@ -717,3 +717,58 @@ func TestGroupedFormatter_MultipleBreakingChanges(t *testing.T) {
 		t.Error("empty Fixes section should not appear")
 	}
 }
+
+func TestKeepAChangelogFormatter_DeterministicOrdering(t *testing.T) {
+
+	cfg := DefaultConfig()
+	formatter := &KeepAChangelogFormatter{config: cfg}
+
+	tests := []struct {
+		name       string
+		grouped    map[string][]*GroupedCommit
+		sortedKeys []string
+	}{
+		{
+			name: "refactor and perf both map to Changed",
+			grouped: map[string][]*GroupedCommit{
+				"Refactors": {
+					{ParsedCommit: &ParsedCommit{Type: "refactor", Description: "clean up parser", CommitInfo: CommitInfo{ShortHash: "aaa"}}, GroupLabel: "Refactors", GroupOrder: 2},
+				},
+				"Performance": {
+					{ParsedCommit: &ParsedCommit{Type: "perf", Description: "optimize query", CommitInfo: CommitInfo{ShortHash: "bbb"}}, GroupLabel: "Performance", GroupOrder: 4},
+				},
+				"Enhancements": {
+					{ParsedCommit: &ParsedCommit{Type: "feat", Description: "add feature", CommitInfo: CommitInfo{ShortHash: "ccc"}}, GroupLabel: "Enhancements", GroupOrder: 0},
+				},
+			},
+			sortedKeys: []string{"Enhancements", "Refactors", "Performance"},
+		},
+		{
+			name: "style and refactor both map to Changed",
+			grouped: map[string][]*GroupedCommit{
+				"Styling": {
+					{ParsedCommit: &ParsedCommit{Type: "style", Description: "format code", CommitInfo: CommitInfo{ShortHash: "ddd"}}, GroupLabel: "Styling", GroupOrder: 5},
+				},
+				"Refactors": {
+					{ParsedCommit: &ParsedCommit{Type: "refactor", Description: "rename var", CommitInfo: CommitInfo{ShortHash: "eee"}}, GroupLabel: "Refactors", GroupOrder: 2},
+				},
+			},
+			sortedKeys: []string{"Refactors", "Styling"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+
+			var first string
+			for i := range 20 {
+				result := formatter.FormatChangelog("v1.0.0", "", tt.grouped, tt.sortedKeys, nil)
+				if i == 0 {
+					first = result
+				} else if result != first {
+					t.Fatalf("non-deterministic output on iteration %d:\nfirst:\n%s\ngot:\n%s", i, first, result)
+				}
+			}
+		})
+	}
+}

--- a/internal/plugins/changeloggenerator/generator.go
+++ b/internal/plugins/changeloggenerator/generator.go
@@ -12,6 +12,7 @@ import (
 	"text/template"
 
 	"github.com/indaco/sley/internal/core"
+	"github.com/indaco/sley/internal/printer"
 	"github.com/indaco/sley/internal/semver"
 )
 
@@ -411,7 +412,10 @@ func (g *Generator) WriteUnifiedChangelog(newContent string) error {
 func (g *Generator) getDefaultHeader() string {
 	// Try to read custom header template
 	if g.config.HeaderTemplate != "" {
-		if data, err := os.ReadFile(g.config.HeaderTemplate); err == nil {
+		data, err := os.ReadFile(g.config.HeaderTemplate)
+		if err != nil {
+			printer.PrintWarning(fmt.Sprintf("Warning: header-template %q not found, using default header", g.config.HeaderTemplate))
+		} else {
 			return strings.TrimSpace(string(data))
 		}
 	}

--- a/internal/plugins/changeloggenerator/generator.go
+++ b/internal/plugins/changeloggenerator/generator.go
@@ -115,6 +115,7 @@ func getProviderFromHost(host string) string {
 type GenerateResult struct {
 	Content                string
 	SkippedNonConventional []*ParsedCommit
+	HasEntries             bool // true if at least one commit group was populated
 }
 
 // GenerateVersionChangelog generates the changelog content for a version.
@@ -177,6 +178,7 @@ func (g *Generator) GenerateVersionChangelogWithResult(version, previousVersion 
 	return GenerateResult{
 		Content:                sb.String(),
 		SkippedNonConventional: groupResult.SkippedNonConventional,
+		HasEntries:             len(grouped) > 0,
 	}
 }
 

--- a/internal/plugins/changeloggenerator/generator_file_test.go
+++ b/internal/plugins/changeloggenerator/generator_file_test.go
@@ -557,6 +557,45 @@ func TestGetDefaultHeader_CustomTemplate(t *testing.T) {
 	}
 }
 
+func TestGetDefaultHeader_MissingTemplateFile(t *testing.T) {
+
+	tests := []struct {
+		name           string
+		headerTemplate string
+	}{
+		{
+			name:           "non-existent path",
+			headerTemplate: "/tmp/nonexistent/header-template-xyz.md",
+		},
+		{
+			name:           "empty string",
+			headerTemplate: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+
+			cfg := DefaultConfig()
+			cfg.HeaderTemplate = tt.headerTemplate
+			g, err := NewGenerator(cfg, NewGitOps())
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+
+			header := g.getDefaultHeader()
+
+			// Should fall back to default header
+			if !strings.Contains(header, "Changelog") {
+				t.Error("expected default header containing 'Changelog'")
+			}
+			if !strings.Contains(header, "Semantic Versioning") {
+				t.Error("expected default header containing 'Semantic Versioning'")
+			}
+		})
+	}
+}
+
 func TestInsertAfterHeader(t *testing.T) {
 
 	cfg := DefaultConfig()

--- a/internal/plugins/changeloggenerator/git.go
+++ b/internal/plugins/changeloggenerator/git.go
@@ -10,6 +10,11 @@ import (
 	"github.com/indaco/sley/internal/git"
 )
 
+// fieldSep is the ASCII unit separator used as a delimiter in git log format strings.
+// This character cannot appear in commit messages, avoiding parsing corruption
+// that would occur with common characters like pipe (|).
+const fieldSep = "\x1f"
+
 // Pre-compiled regexes for URL parsing (compiled once at package init).
 var (
 	// Remote URL formats
@@ -110,8 +115,7 @@ func (g *GitOps) getCommitsWithMeta(since, until string) ([]CommitInfo, error) {
 	}
 
 	revRange := since + ".." + until
-	// Use a delimiter that's unlikely to appear in commit messages
-	format := "%H|%h|%s|%an|%ae"
+	format := "%H" + fieldSep + "%h" + fieldSep + "%s" + fieldSep + "%an" + fieldSep + "%ae"
 	args := []string{"log", "--pretty=format:" + format, revRange}
 	// Scope to module path if set (only commits touching this directory)
 	if g.ModulePath != "" {
@@ -138,7 +142,7 @@ func (g *GitOps) getCommitsWithMeta(since, until string) ([]CommitInfo, error) {
 
 	commits := make([]CommitInfo, 0, len(lines))
 	for _, line := range lines {
-		parts := strings.SplitN(line, "|", 5)
+		parts := strings.SplitN(line, fieldSep, 5)
 		if len(parts) < 5 {
 			continue // Skip malformed lines
 		}
@@ -339,7 +343,7 @@ func (g *GitOps) getHistoricalContributors(beforeRef string) (map[string]struct{
 
 	// git log --format="%ae|%an" beforeRef
 	// Returns all author emails and names from the beginning of history up to beforeRef
-	cmd := g.ExecCommandFn("git", "log", "--format=%ae|%an", beforeRef)
+	cmd := g.ExecCommandFn("git", "log", "--format=%ae"+fieldSep+"%an", beforeRef)
 	var stderr bytes.Buffer
 	cmd.Stderr = &stderr
 
@@ -359,7 +363,7 @@ func (g *GitOps) getHistoricalContributors(beforeRef string) (map[string]struct{
 		if line == "" {
 			continue
 		}
-		parts := strings.SplitN(line, "|", 2)
+		parts := strings.SplitN(line, fieldSep, 2)
 		if len(parts) < 2 {
 			continue
 		}

--- a/internal/plugins/changeloggenerator/git_test.go
+++ b/internal/plugins/changeloggenerator/git_test.go
@@ -9,6 +9,12 @@ import (
 
 var fakeGitCommands = map[string]string{}
 
+// s is a shorthand alias for fieldSep to keep test fixtures readable.
+var s = fieldSep
+
+// commitLogFormat is the git log --pretty=format string used by getCommitsWithMeta.
+var commitLogFormat = "git log --pretty=format:%H" + s + "%h" + s + "%s" + s + "%an" + s + "%ae"
+
 func fakeExecCommand(command string, args ...string) *exec.Cmd {
 	cmdStr := command + " " + strings.Join(args, " ")
 	cmd := exec.Command(os.Args[0], "-test.run=TestHelperProcess", "--", cmdStr) //nolint:gosec // standard test re-exec pattern
@@ -52,7 +58,7 @@ func TestGetCommitsWithMeta(t *testing.T) {
 			since: "v1.0.0",
 			until: "HEAD",
 			mockGitCommands: map[string]string{
-				"git log --pretty=format:%H|%h|%s|%an|%ae v1.0.0..HEAD": "abc123|abc123|feat: login|Alice|alice@example.com\ndef456|def456|fix: bug|Bob|bob@example.com",
+				commitLogFormat + " v1.0.0..HEAD": "abc123" + s + "abc123" + s + "feat: login" + s + "Alice" + s + "alice@example.com\ndef456" + s + "def456" + s + "fix: bug" + s + "Bob" + s + "bob@example.com",
 			},
 			expectedCount: 2,
 		},
@@ -61,9 +67,9 @@ func TestGetCommitsWithMeta(t *testing.T) {
 			since: "",
 			until: "HEAD",
 			mockGitCommands: map[string]string{
-				"git describe --tags --abbrev=0":                         "", // no tags
-				"git rev-list --count HEAD":                              "25",
-				"git log --pretty=format:%H|%h|%s|%an|%ae HEAD~10..HEAD": "abc123|abc123|feat: update|Alice|alice@example.com",
+				"git describe --tags --abbrev=0":   "", // no tags
+				"git rev-list --count HEAD":        "25",
+				commitLogFormat + " HEAD~10..HEAD": "abc123" + s + "abc123" + s + "feat: update" + s + "Alice" + s + "alice@example.com",
 			},
 			expectedCount: 1,
 		},
@@ -72,10 +78,10 @@ func TestGetCommitsWithMeta(t *testing.T) {
 			since: "",
 			until: "HEAD",
 			mockGitCommands: map[string]string{
-				"git describe --tags --abbrev=0":                         "", // no tags
-				"git rev-list --count HEAD":                              "2",
-				"git rev-list --max-parents=0 HEAD":                      "root123",
-				"git log --pretty=format:%H|%h|%s|%an|%ae root123..HEAD": "abc123|abc123|feat: init|Alice|alice@example.com",
+				"git describe --tags --abbrev=0":    "", // no tags
+				"git rev-list --count HEAD":         "2",
+				"git rev-list --max-parents=0 HEAD": "root123",
+				commitLogFormat + " root123..HEAD":  "abc123" + s + "abc123" + s + "feat: init" + s + "Alice" + s + "alice@example.com",
 			},
 			expectedCount: 1,
 		},
@@ -84,8 +90,8 @@ func TestGetCommitsWithMeta(t *testing.T) {
 			since: "",
 			until: "HEAD",
 			mockGitCommands: map[string]string{
-				"git describe --tags --abbrev=0":                        "v2.0.0",
-				"git log --pretty=format:%H|%h|%s|%an|%ae v2.0.0..HEAD": "abc123|abc123|feat: new|Alice|alice@example.com",
+				"git describe --tags --abbrev=0":  "v2.0.0",
+				commitLogFormat + " v2.0.0..HEAD": "abc123" + s + "abc123" + s + "feat: new" + s + "Alice" + s + "alice@example.com",
 			},
 			expectedCount: 1,
 		},
@@ -94,7 +100,7 @@ func TestGetCommitsWithMeta(t *testing.T) {
 			since: "v1.0.0",
 			until: "HEAD",
 			mockGitCommands: map[string]string{
-				"git log --pretty=format:%H|%h|%s|%an|%ae v1.0.0..HEAD": "ERROR",
+				commitLogFormat + " v1.0.0..HEAD": "ERROR",
 			},
 			expectErr: true,
 		},
@@ -103,7 +109,7 @@ func TestGetCommitsWithMeta(t *testing.T) {
 			since: "v1.0.0",
 			until: "HEAD",
 			mockGitCommands: map[string]string{
-				"git log --pretty=format:%H|%h|%s|%an|%ae v1.0.0..HEAD": "",
+				commitLogFormat + " v1.0.0..HEAD": "",
 			},
 			expectedCount: 0,
 		},
@@ -121,6 +127,67 @@ func TestGetCommitsWithMeta(t *testing.T) {
 			}
 			if len(commits) != tt.expectedCount {
 				t.Fatalf("expected %d commits, got %d", tt.expectedCount, len(commits))
+			}
+		})
+	}
+}
+
+func TestGetCommitsWithMeta_PipeInSubject(t *testing.T) {
+
+	tests := []struct {
+		name        string
+		mockOutput  string
+		wantSubject string
+		wantAuthor  string
+		wantEmail   string
+	}{
+		{
+			name:        "pipe in subject is preserved",
+			mockOutput:  "abc123" + s + "abc1" + s + "feat: add A | B support" + s + "Alice" + s + "alice@example.com",
+			wantSubject: "feat: add A | B support",
+			wantAuthor:  "Alice",
+			wantEmail:   "alice@example.com",
+		},
+		{
+			name:        "multiple pipes in subject",
+			mockOutput:  "def456" + s + "def4" + s + "fix: handle X | Y | Z" + s + "Bob" + s + "bob@example.com",
+			wantSubject: "fix: handle X | Y | Z",
+			wantAuthor:  "Bob",
+			wantEmail:   "bob@example.com",
+		},
+		{
+			name:        "no pipe in subject",
+			mockOutput:  "ghi789" + s + "ghi7" + s + "feat: normal change" + s + "Charlie" + s + "charlie@example.com",
+			wantSubject: "feat: normal change",
+			wantAuthor:  "Charlie",
+			wantEmail:   "charlie@example.com",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			fakeGitCommands = map[string]string{
+				commitLogFormat + " v1.0.0..HEAD": tt.mockOutput,
+			}
+
+			g := &GitOps{ExecCommandFn: fakeExecCommand}
+			commits, err := g.getCommitsWithMeta("v1.0.0", "HEAD")
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if len(commits) != 1 {
+				t.Fatalf("expected 1 commit, got %d", len(commits))
+			}
+
+			c := commits[0]
+			if c.Subject != tt.wantSubject {
+				t.Errorf("Subject = %q, want %q", c.Subject, tt.wantSubject)
+			}
+			if c.Author != tt.wantAuthor {
+				t.Errorf("Author = %q, want %q", c.Author, tt.wantAuthor)
+			}
+			if c.AuthorEmail != tt.wantEmail {
+				t.Errorf("AuthorEmail = %q, want %q", c.AuthorEmail, tt.wantEmail)
 			}
 		})
 	}

--- a/internal/plugins/changeloggenerator/plugin.go
+++ b/internal/plugins/changeloggenerator/plugin.go
@@ -140,6 +140,11 @@ func (p *ChangelogGeneratorPlugin) GenerateForVersion(version, previousVersion, 
 		fmt.Fprintf(os.Stderr, "%s Use conventional commit format (type: description) or set 'include-non-conventional: true' in config.\n\n", printer.Info("Tip:"))
 	}
 
+	// Skip writing if no substantive content was generated
+	if !result.HasEntries {
+		return nil
+	}
+
 	// Write based on mode
 	return p.writeChangelog(version, result.Content)
 }

--- a/internal/plugins/changeloggenerator/plugin.go
+++ b/internal/plugins/changeloggenerator/plugin.go
@@ -99,6 +99,13 @@ func (p *ChangelogGeneratorPlugin) SetModuleName(name string) {
 	p.moduleName = name
 }
 
+// SetChangelogPath overrides the unified changelog file path for the next generation cycle.
+// Used to scope output per module in independent versioning workspaces.
+func (p *ChangelogGeneratorPlugin) SetChangelogPath(path string) {
+	p.config.ChangelogPath = path
+	p.generator.config.ChangelogPath = path
+}
+
 // SetModulePath scopes git log to commits touching the given directory.
 // Pass "" to clear the filter and include all commits.
 func (p *ChangelogGeneratorPlugin) SetModulePath(path string) {

--- a/internal/plugins/changeloggenerator/plugin_test.go
+++ b/internal/plugins/changeloggenerator/plugin_test.go
@@ -700,3 +700,180 @@ func TestWriteChangelog_Both(t *testing.T) {
 		t.Errorf("expected CHANGELOG.md at %s", cfg.ChangelogPath)
 	}
 }
+
+func TestGenerateForVersion_SkippedWhenAllNonConventional(t *testing.T) {
+
+	tests := []struct {
+		name                   string
+		commits                []CommitInfo
+		includeNonConventional bool
+		expectFile             bool
+	}{
+		{
+			name: "all non-conventional not included",
+			commits: []CommitInfo{
+				{Hash: "aaa", ShortHash: "aaa", Subject: "update readme", Author: "Test", AuthorEmail: "test@example.com"},
+				{Hash: "bbb", ShortHash: "bbb", Subject: "bump dependencies", Author: "Test", AuthorEmail: "test@example.com"},
+			},
+			includeNonConventional: false,
+			expectFile:             false,
+		},
+		{
+			name: "all non-conventional included",
+			commits: []CommitInfo{
+				{Hash: "aaa", ShortHash: "aaa", Subject: "update readme", Author: "Test", AuthorEmail: "test@example.com"},
+			},
+			includeNonConventional: true,
+			expectFile:             true,
+		},
+		{
+			name: "mix of conventional and non-conventional",
+			commits: []CommitInfo{
+				{Hash: "aaa", ShortHash: "aaa", Subject: "feat: add X", Author: "Test", AuthorEmail: "test@example.com"},
+				{Hash: "bbb", ShortHash: "bbb", Subject: "update readme", Author: "Test", AuthorEmail: "test@example.com"},
+			},
+			includeNonConventional: false,
+			expectFile:             true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+
+			tmpDir := t.TempDir()
+
+			cfg := DefaultConfig()
+			cfg.Enabled = true
+			cfg.Mode = "versioned"
+			cfg.ChangesDir = filepath.Join(tmpDir, ".changes")
+			cfg.IncludeNonConventional = tt.includeNonConventional
+			cfg.Repository = &RepositoryConfig{
+				Provider: "github",
+				Host:     "github.com",
+				Owner:    "testowner",
+				Repo:     "testrepo",
+			}
+			plugin, err := NewChangelogGenerator(cfg)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+
+			plugin.gitOps.GetCommitsWithMetaFn = func(since, until string) ([]CommitInfo, error) {
+				return tt.commits, nil
+			}
+
+			err = plugin.GenerateForVersion("v1.0.0", "v0.9.0", "patch")
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+
+			versionedPath := filepath.Join(cfg.ChangesDir, "v1.0.0.md")
+			_, statErr := os.Stat(versionedPath)
+
+			if tt.expectFile && os.IsNotExist(statErr) {
+				t.Errorf("expected versioned file at %s", versionedPath)
+			}
+			if !tt.expectFile && statErr == nil {
+				t.Errorf("expected no versioned file at %s, but it exists", versionedPath)
+			}
+		})
+	}
+}
+
+func TestGenerateForVersion_ModuleScoped_VersionedMode(t *testing.T) {
+
+	tests := []struct {
+		name            string
+		mode            string
+		moduleName      string
+		modulePath      string
+		expectVersioned string // relative to tmpDir
+		checkUnified    bool
+		unifiedContain  string
+	}{
+		{
+			name:            "submodule versioned",
+			mode:            "versioned",
+			moduleName:      "cobra",
+			modulePath:      "cobra",
+			expectVersioned: ".changes/cobra/v1.0.0.md",
+		},
+		{
+			name:           "submodule unified",
+			mode:           "unified",
+			moduleName:     "cobra",
+			modulePath:     "cobra",
+			checkUnified:   true,
+			unifiedContain: "## cobra - v1.0.0",
+		},
+		{
+			name:            "submodule both",
+			mode:            "both",
+			moduleName:      "cobra",
+			modulePath:      "cobra",
+			expectVersioned: ".changes/cobra/v1.0.0.md",
+			checkUnified:    true,
+			unifiedContain:  "## cobra - v1.0.0",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+
+			tmpDir := t.TempDir()
+
+			cfg := DefaultConfig()
+			cfg.Enabled = true
+			cfg.Mode = tt.mode
+			cfg.ChangesDir = filepath.Join(tmpDir, ".changes")
+			cfg.ChangelogPath = filepath.Join(tmpDir, "CHANGELOG.md")
+			cfg.Repository = &RepositoryConfig{
+				Provider: "github",
+				Host:     "github.com",
+				Owner:    "testowner",
+				Repo:     "testrepo",
+			}
+			cfg.Contributors = &ContributorsConfig{Enabled: false}
+
+			plugin, err := NewChangelogGenerator(cfg)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+
+			plugin.gitOps.GetCommitsWithMetaFn = func(since, until string) ([]CommitInfo, error) {
+				return []CommitInfo{
+					{Hash: "abc123", ShortHash: "abc123", Subject: "feat: add cobra command", Author: "Test", AuthorEmail: "test@example.com"},
+				}, nil
+			}
+
+			// Apply module scoping
+			plugin.SetModuleName(tt.moduleName)
+			plugin.SetChangesDir(filepath.Join(cfg.ChangesDir, tt.modulePath))
+			plugin.SetModulePath(tt.modulePath)
+
+			err = plugin.GenerateForVersion("v1.0.0", "", "minor")
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+
+			// Check versioned file
+			if tt.expectVersioned != "" {
+				path := filepath.Join(tmpDir, tt.expectVersioned)
+				if _, err := os.Stat(path); os.IsNotExist(err) {
+					t.Errorf("expected versioned file at %s", path)
+				}
+			}
+
+			// Check unified file
+			if tt.checkUnified {
+				data, err := os.ReadFile(cfg.ChangelogPath)
+				if err != nil {
+					t.Fatalf("failed to read CHANGELOG.md: %v", err)
+				}
+				if !strings.Contains(string(data), tt.unifiedContain) {
+					t.Errorf("CHANGELOG.md should contain %q, got:\n%s", tt.unifiedContain, string(data))
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Description

Fixes and improvements to the `changelog-generator` plugin:

- **KaC ordering fix**: `regroupCommits` iterated a Go map, causing non-deterministic commit ordering when multiple original groups mapped to the same _Keep a Changelog_ section. Now iterates `sortedKeys` for stable output.
- **Header-template warning**: missing `header-template` file was silently ignored. Now prints a warning to stderr.
- **Empty versioned files**: when all commits are non-conventional and `include-non-conventional: false`, no longer writes a header-only `.changes/v*.md` file.
- **Safer delimiter**: replaced `|` with `\x1f` (ASCII unit separator) in git log format strings to prevent commit subjects containing `|` from corrupting field parsing.
- **Per-module changelog**: when `workspace.versioning: independent`, writes unified changelog to `{modulePath}/CHANGELOG.md` instead of root.

## Related Issue

- None

## Notes for Reviewers

- None
